### PR TITLE
Feature/v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ To use **page-hunter** from GitHub repository with specific version, set the dep
 
 ```ini
 [dependencies]
-page-hunter = {git = "https://github.com/JMTamayo/page-hunter.git", version = "0.1.4", features = ["serde"] }
+page-hunter = { git = "https://github.com/JMTamayo/page-hunter.git", version = "0.2.0", features = ["serde"] }
 ```
 
 You can depend on it via cargo by adding the following dependency to your `Cargo.toml` file:
 
 ```ini
 [dependencies]
-page-hunter = { version = "0.1.4", features = ["utoipa", "pg-sqlx"] }
+page-hunter = { version = "0.2.0", features = ["utoipa", "pg-sqlx"] }
 ```
 
 ## CRATE FEATURES
-- `serde`: Add [Serialize](https://docs.rs/serde/1.0.203/serde/trait.Serialize.html) and [Deserialize](https://docs.rs/serde/1.0.197/serde/trait.Deserialize.html) support for `Page` and `Book` based on [serde](https://crates.io/crates/serde/1.0.203). This feature is useful for implementing pagination models as a request or response body in REST APIs, among other implementations.
+- `serde`: Add [Serialize](https://docs.rs/serde/1.0.203/serde/trait.Serialize.html) and [Deserialize](https://docs.rs/serde/1.0.203/serde/trait.Deserialize.html) support for `Page` and `Book` based on [serde](https://crates.io/crates/serde/1.0.203). This feature is useful for implementing pagination models as a request or response body in REST APIs, among other implementations.
 - `utoipa`: Add [ToSchema](https://docs.rs/utoipa/4.2.3/utoipa/trait.ToSchema.html) support for `Page` and  `Book` based on [utoipa](https://crates.io/crates/utoipa/4.2.3). This feature is useful for generating OpenAPI schemas for pagination models. This feature depends on the `serde` feature and therefore you only need to implement `utoipa` to get both.
 - `pg-sqlx`: Add support for pagination with [SQLx](https://docs.rs/sqlx/0.7.4/sqlx/) for PostgreSQL database.
 - `mysql-sqlx`: Add support for pagination with [SQLx](https://docs.rs/sqlx/0.7.4/sqlx/) for MySQL database.
@@ -162,10 +162,10 @@ On feature `serde` enabled, you can serialize and deserialize a `Book` as follow
 
 	#[derive(Clone, ToSchema)]
 	pub struct Person {
-		id: u16,
-		name: String,
-		last_name: String,
-		still_alive: bool,
+        id: u16,
+        name: String,
+        last_name: String,
+        still_alive: bool,
 	}
 
 	pub type PeoplePage = Page<Person>;

--- a/examples/actix-web/src/api/routes.rs
+++ b/examples/actix-web/src/api/routes.rs
@@ -43,7 +43,7 @@ pub async fn search_departments_pagination(
     let page: Page<Department> =
         match paginate_records(&departments, params.get_page(), params.get_size()) {
             Ok(page) => page,
-            Err(error) => return Exception::new(500, error.to_string()).to_http_response(),
+            Err(error) => return Exception::new(417, error.to_string()).to_http_response(),
         };
 
     HttpResponse::Ok().json(page)
@@ -78,7 +78,7 @@ pub async fn search_all_departments(
 
     let book: Book<Department> = match bind_records(&departments, params.get_size()) {
         Ok(book) => book,
-        Err(error) => return Exception::new(500, error.to_string()).to_http_response(),
+        Err(error) => return Exception::new(417, error.to_string()).to_http_response(),
     };
 
     HttpResponse::Ok().json(book)

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "axum-example"
+description = "An example of how to use axum with page-hunter to build a PosgreSQL database manager with SQLx"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+tokio = { version = "1.38.0", features = ["full"] }
+axum = { version = "0.7.5" }
+utoipa = {version = "4.2.3", features = ["axum_extras", "uuid", "time"] }
+utoipa-swagger-ui = { version = "7.1.0", features = ["axum"] }
+sqlx = { version = "0.7.4", features = ["runtime-tokio", "uuid", "time",  "postgres"] }
+page-hunter = { path = "../../page-hunter", features=["utoipa", "pg-sqlx"] }
+serde = { version = "1.0.203", features = ["derive"] }
+time = { version = "0.3.36", features = ["serde"] }
+uuid = { version = "1.8.0", features = ["serde"] }
+env_logger = { version = "0.11.3" }
+log = { version = "0.4.21" }
+
+[workspace]

--- a/examples/axum/Makefile
+++ b/examples/axum/Makefile
@@ -1,0 +1,14 @@
+install-sqlx-cli:
+	cargo install sqlx-cli --no-default-features --features postgres
+
+run-db-container:
+	docker run --name postgres-db-dev -e POSTGRES_PASSWORD=pswrd -e POSTGRES_DB=supermarket -e POSTGRES_USER=usr -p 5432:5432 -d postgres
+
+run-db-migrations:
+	 sqlx migrate run --source src/db/migrations --database-url postgres://usr:pswrd@localhost:5432/supermarket
+
+revert-db-migrations:
+	sqlx migrate revert --source src/db/migrations --database-url postgres://usr:pswrd@localhost:5432/supermarket
+
+run:
+	cargo run --release

--- a/examples/axum/README.md
+++ b/examples/axum/README.md
@@ -1,0 +1,26 @@
+# USING AXUM WITH PAGE HUNTER AND POSTGRESQL
+Use [axum](https://docs.rs/crate/axum/0.7.5) to build a web server using `page-hunter` to paginate APIs responses and PostgreSQL to manage data.
+
+This service uses a PostgreSQL database as a docker container to manage example data.
+
+To try this example on your local computer, you just need to locate to the respective folder and run the following command:
+
+1. Install sqlx-cli:
+```bash
+	make install-sqlx-cli
+```
+
+2. Run database container:
+```bash
+	make run-db-container
+```
+
+3. Run the application:
+```bash
+	make run
+```
+
+When the service is running, you can explore the documentation as follows:
+- **Swagger UI:** http://localhost:8080/swagger-ui/
+
+Enjoy it! 😀

--- a/examples/axum/src/api/mod.rs
+++ b/examples/axum/src/api/mod.rs
@@ -1,0 +1,2 @@
+pub mod router;
+pub mod routes;

--- a/examples/axum/src/api/router.rs
+++ b/examples/axum/src/api/router.rs
@@ -1,0 +1,34 @@
+use axum::Router;
+
+use crate::api::routes::categories::CategoriesServiceHandler;
+use crate::api::routes::docs::DocsRouter;
+
+use super::routes::products::ProductsServiceHandler;
+
+pub trait ServiceRouter {
+    fn new() -> Self;
+    fn get_path_base(&self) -> &str;
+    fn get_router(&self) -> Router;
+}
+
+pub struct ApiRouter {}
+
+impl ServiceRouter for ApiRouter {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn get_path_base(&self) -> &str {
+        "/"
+    }
+
+    fn get_router(&self) -> Router {
+        Router::new().nest(
+            self.get_path_base(),
+            Router::new()
+                .merge(CategoriesServiceHandler::new().get_router())
+                .merge(ProductsServiceHandler::new().get_router())
+                .merge(DocsRouter::new().get_router()),
+        )
+    }
+}

--- a/examples/axum/src/api/routes/categories.rs
+++ b/examples/axum/src/api/routes/categories.rs
@@ -1,0 +1,106 @@
+use axum::{
+    extract::{Path, Query},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Extension, Json, Router,
+};
+use log::info;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::api::router::ServiceRouter;
+use crate::db::handler::Repository;
+use crate::db::repository::categories::{CategoriesRepository, CategoriesRepositoryMethods};
+use crate::models::categories::{Category, PaginatedCategories, SearchCategoriesRequest};
+use crate::models::errors::HttpException;
+
+pub struct CategoriesServiceHandler {
+    path_base: String,
+}
+
+impl ServiceRouter for CategoriesServiceHandler {
+    fn new() -> Self {
+        Self {
+            path_base: String::from("/categories"),
+        }
+    }
+
+    fn get_path_base(&self) -> &str {
+        &self.path_base
+    }
+
+    fn get_router(&self) -> Router {
+        Router::new().nest(
+            self.get_path_base(),
+            Router::new()
+                .route("/:id", get(get_category_by_id))
+                .route("/", get(list_categories)),
+        )
+    }
+}
+
+#[utoipa::path(
+	get,
+	tag = "Categories",
+	path = "/categories/{id}",
+	params(
+		("id" = Uuid, Path, description = "Category id")
+	),
+	responses(
+		(status = StatusCode::OK, body = Category),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn get_category_by_id(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Path(id): Path<Uuid>,
+) -> Response {
+    info!("Getting category by id: {id}");
+
+    let category: Category = match CategoriesRepository::new(&pool)
+        .get_category_by_id(id)
+        .await
+    {
+        Ok(category) => category,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    info!("Category found: {:?}", &category);
+
+    (StatusCode::OK, Json(category)).into_response()
+}
+
+#[utoipa::path(
+	get,
+	tag = "Categories",
+	path = "/categories",
+	params(
+		SearchCategoriesRequest,
+	),
+	responses(
+		(status = StatusCode::OK, body = Page<Category>),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn list_categories(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Query(params): Query<SearchCategoriesRequest>,
+) -> Response {
+    info!("Searching categories by: {:?}", &params);
+
+    let categories: PaginatedCategories = match CategoriesRepository::new(&pool)
+        .list_categories(&params)
+        .await
+    {
+        Ok(categories) => categories,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    info!("Categories found: {:?}", &categories);
+
+    (StatusCode::OK, Json(categories)).into_response()
+}

--- a/examples/axum/src/api/routes/docs.rs
+++ b/examples/axum/src/api/routes/docs.rs
@@ -1,0 +1,31 @@
+use axum::Router;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
+use crate::api::router::ServiceRouter;
+use crate::docs::open_api::ApiDoc;
+
+pub struct DocsRouter {
+    path_base: String,
+}
+
+impl ServiceRouter for DocsRouter {
+    fn new() -> Self {
+        Self {
+            path_base: String::from(""),
+        }
+    }
+
+    fn get_path_base(&self) -> &str {
+        &self.path_base
+    }
+
+    fn get_router(&self) -> Router {
+        Router::new().nest(
+            self.get_path_base(),
+            Router::new().merge(
+                SwaggerUi::new("/swagger-ui").url("/docs/api-docs/openapi.json", ApiDoc::openapi()),
+            ),
+        )
+    }
+}

--- a/examples/axum/src/api/routes/mod.rs
+++ b/examples/axum/src/api/routes/mod.rs
@@ -1,0 +1,3 @@
+pub mod categories;
+pub mod docs;
+pub mod products;

--- a/examples/axum/src/api/routes/products.rs
+++ b/examples/axum/src/api/routes/products.rs
@@ -1,0 +1,206 @@
+use axum::{
+    extract::{Path, Query},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{delete, get, patch, post},
+    Extension, Json, Router,
+};
+use log::info;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::{api::router::ServiceRouter, models::products::UpdateProductQuantityRequest};
+
+use crate::db::handler::Repository;
+use crate::db::repository::products::{ProductsRepository, ProductsRepositoryMethods};
+
+use crate::models::errors::HttpException;
+use crate::models::products::{
+    CreateProductRequest, PaginatedProducts, Product, ProductId, SearchProductsRequest,
+};
+
+pub struct ProductsServiceHandler {
+    path_base: String,
+}
+
+impl ServiceRouter for ProductsServiceHandler {
+    fn new() -> Self {
+        Self {
+            path_base: String::from("/products"),
+        }
+    }
+
+    fn get_path_base(&self) -> &str {
+        &self.path_base
+    }
+
+    fn get_router(&self) -> Router {
+        Router::new().nest(
+            self.get_path_base(),
+            Router::new()
+                .route("/", post(create_product))
+                .route("/:id", get(get_product_by_id))
+                .route("/:id", delete(delete_product))
+                .route("/", get(list_products))
+                .route("/:id/quantity", patch(update_product_quantity)),
+        )
+    }
+}
+
+#[utoipa::path(
+	post,
+	tag = "Products",
+	path = "/products",
+	request_body = CreateProductRequest,
+	responses(
+		(status = StatusCode::CREATED, body = Product),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn create_product(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Json(product): Json<CreateProductRequest>,
+) -> Response {
+    info!("Creating product: {:?}", &product);
+
+    let repository: ProductsRepository = ProductsRepository::new(&pool);
+
+    let id: ProductId = match repository.create_product(&product).await {
+        Ok(product) => product,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    let product: Product = match repository.get_product_by_id(id.get_id()).await {
+        Ok(product) => product,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    info!("Product created: {:?}", &product);
+
+    (StatusCode::CREATED, Json(product)).into_response()
+}
+
+#[utoipa::path(
+	get,
+	tag = "Products",
+	path = "/products/{id}",
+	params(
+		("id" = Uuid, Path, description = "Product id")
+	),
+	responses(
+		(status = StatusCode::OK, body = Product),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn get_product_by_id(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Path(id): Path<Uuid>,
+) -> Response {
+    info!("Getting product by id: {id}");
+
+    let product: Product = match ProductsRepository::new(&pool).get_product_by_id(id).await {
+        Ok(product) => product,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    info!("Product found: {:?}", &product);
+
+    (StatusCode::OK, Json(product)).into_response()
+}
+
+#[utoipa::path(
+	get,
+	tag = "Products",
+	path = "/products",
+	params(
+		SearchProductsRequest,
+	),
+	responses(
+		(status = StatusCode::OK, body = Page<Product>),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn list_products(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Query(params): Query<SearchProductsRequest>,
+) -> Response {
+    info!("Searching products by: {:?}", &params);
+
+    let products: PaginatedProducts =
+        match ProductsRepository::new(&pool).list_products(&params).await {
+            Ok(products) => products,
+            Err(error) => return HttpException::from(error).into(),
+        };
+
+    info!("Products found: {:?}", &products);
+
+    (StatusCode::OK, Json(products)).into_response()
+}
+
+#[utoipa::path(
+	delete,
+	tag = "Products",
+	path = "/products/{id}",
+	params(
+		("id" = Uuid, Path, description = "Product id")
+	),
+	responses(
+		(status = StatusCode::OK, body = ProductId),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn delete_product(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Path(id): Path<Uuid>,
+) -> Response {
+    info!("Deletting product by id: {id}");
+
+    let product: ProductId = match ProductsRepository::new(&pool).delete_product(id).await {
+        Ok(product) => product,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    info!("Product deleted: {:?}", &product);
+
+    (StatusCode::OK, Json(product)).into_response()
+}
+
+#[utoipa::path(
+	patch,
+	tag = "Products",
+	path = "/products/{id}/quantity",
+	request_body = UpdateProductQuantityRequest,
+	responses(
+		(status = StatusCode::OK, body = Product),
+		(status = StatusCode::NOT_FOUND, body = HttpException),
+		(status = StatusCode::INTERNAL_SERVER_ERROR, body = HttpException),
+	),
+)]
+pub async fn update_product_quantity(
+    Extension(pool): Extension<Arc<PgPool>>,
+    Path(id): Path<Uuid>,
+    Json(update_by): Json<UpdateProductQuantityRequest>,
+) -> Response {
+    info!("Updating product {id}: {:?}", &update_by);
+
+    let repository: ProductsRepository = ProductsRepository::new(&pool);
+
+    let id: ProductId = match repository.update_product_quantity(id, &update_by).await {
+        Ok(product) => product,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    let product: Product = match repository.get_product_by_id(id.get_id()).await {
+        Ok(product) => product,
+        Err(error) => return HttpException::from(error).into(),
+    };
+
+    info!("Product updated: {:?}", &product);
+
+    (StatusCode::OK, Json(product)).into_response()
+}

--- a/examples/axum/src/config/conf.rs
+++ b/examples/axum/src/config/conf.rs
@@ -1,0 +1,126 @@
+use std::{
+    env,
+    net::{Ipv4Addr, SocketAddr},
+};
+
+pub struct AxumServerConfig {
+    name: String,
+    port: u16,
+    log_level: String,
+}
+
+impl AxumServerConfig {
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn get_port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn get_log_level(&self) -> &str {
+        &self.log_level
+    }
+
+    pub fn get_service_address(&self) -> SocketAddr {
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, self.get_port()))
+    }
+
+    pub fn get() -> Self {
+        AxumServerConfig {
+            name: env::var("SERVICE_NAME").unwrap_or("supermarket-inventory-manager".to_string()),
+
+            port: env::var("PORT")
+                .unwrap_or("8080".to_string())
+                .parse::<u16>()
+                .unwrap_or_else(|error| panic!("Error parsing PORT as u16: {error}")),
+
+            log_level: env::var("LOG_LEVEL").unwrap_or("debug".to_string()),
+        }
+    }
+}
+
+pub struct DatabaseConfig {
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+    database: String,
+    max_pool_db_connections: u32,
+}
+
+impl DatabaseConfig {
+    pub fn get_host(&self) -> &str {
+        &self.host
+    }
+
+    pub fn get_port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn get_username(&self) -> &str {
+        &self.username
+    }
+
+    pub fn get_password(&self) -> &str {
+        &self.password
+    }
+
+    pub fn get_database(&self) -> &str {
+        &self.database
+    }
+
+    pub fn get_max_pool_db_connections(&self) -> u32 {
+        self.max_pool_db_connections
+    }
+
+    pub fn get() -> Self {
+        DatabaseConfig {
+            host: env::var("DB_HOST")
+                .unwrap_or_else(|error| panic!("Error getting DB_HOST from env: {error}")),
+
+            port: env::var("DB_PORT")
+                .unwrap_or_else(|error| panic!("Error getting DB_PORT from env: {error}"))
+                .parse::<u16>()
+                .unwrap_or_else(|error| panic!("Error parsing DB_PORT as u16: {error}")),
+
+            username: env::var("DB_USERNAME")
+                .unwrap_or_else(|error| panic!("Error getting DB_USERNAME from env: {error}")),
+
+            password: env::var("DB_PASSWORD")
+                .unwrap_or_else(|error| panic!("Error getting DB_PASSWORD from env: {error}")),
+
+            database: env::var("DB_DATABASE")
+                .unwrap_or_else(|error| panic!("Error getting DB_DATABASE from env: {error}")),
+
+            max_pool_db_connections: env::var("MAX_POOL_DB_CONNECTIONS")
+                .unwrap_or("10".to_string())
+                .parse::<u32>()
+                .unwrap_or_else(|error| {
+                    panic!("Error parsing MAX_POOL_DB_CONNECTIONS as u32: {error}")
+                }),
+        }
+    }
+}
+
+pub struct Conf {
+    server_config: AxumServerConfig,
+    database_config: DatabaseConfig,
+}
+
+impl Conf {
+    pub fn get_server_config(&self) -> &AxumServerConfig {
+        &self.server_config
+    }
+
+    pub fn get_database_config(&self) -> &DatabaseConfig {
+        &self.database_config
+    }
+
+    pub fn get() -> Self {
+        Conf {
+            server_config: AxumServerConfig::get(),
+            database_config: DatabaseConfig::get(),
+        }
+    }
+}

--- a/examples/axum/src/config/logconfig.rs
+++ b/examples/axum/src/config/logconfig.rs
@@ -1,0 +1,12 @@
+use env_logger::{fmt, Builder, Env};
+
+pub struct LogConfig {}
+
+impl LogConfig {
+    pub fn init_logger(log_level: &str) {
+        Builder::from_env(Env::default().default_filter_or(log_level))
+            .format_timestamp(Some(fmt::TimestampPrecision::Millis))
+            .format_module_path(false)
+            .init()
+    }
+}

--- a/examples/axum/src/config/mod.rs
+++ b/examples/axum/src/config/mod.rs
@@ -1,0 +1,2 @@
+pub mod conf;
+pub mod logconfig;

--- a/examples/axum/src/db/handler.rs
+++ b/examples/axum/src/db/handler.rs
@@ -1,0 +1,35 @@
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::{migrate::MigrateError, Error as SqlxError};
+
+use crate::config::conf::DatabaseConfig;
+
+pub trait Repository<'p> {
+    fn get_pool(&self) -> &'p PgPool;
+    fn new(pool: &'p PgPool) -> Self;
+}
+
+pub struct DbHandler {}
+
+impl DbHandler {
+    pub fn new() -> Self {
+        DbHandler {}
+    }
+
+    pub async fn get_pool(&self, db_conf: &DatabaseConfig) -> Result<PgPool, SqlxError> {
+        PgPoolOptions::new()
+            .max_connections(db_conf.get_max_pool_db_connections())
+            .connect(&format!(
+                "postgres://{user}:{password}@{host}:{port}/{db}",
+                user = db_conf.get_username(),
+                password = db_conf.get_password(),
+                host = db_conf.get_host(),
+                port = db_conf.get_port(),
+                db = db_conf.get_database(),
+            ))
+            .await
+    }
+
+    pub async fn run_migrations(&self, pool: &PgPool) -> Result<(), MigrateError> {
+        sqlx::migrate!("./src/db/migrations").run(pool).await
+    }
+}

--- a/examples/axum/src/db/migrations/20240530134613_create_schema_inventory.down.sql
+++ b/examples/axum/src/db/migrations/20240530134613_create_schema_inventory.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+DROP SCHEMA IF EXISTS inventory;
+
+DROP EXTENSION "uuid-ossp";

--- a/examples/axum/src/db/migrations/20240530134613_create_schema_inventory.up.sql
+++ b/examples/axum/src/db/migrations/20240530134613_create_schema_inventory.up.sql
@@ -1,0 +1,4 @@
+-- Add up migration script here
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE SCHEMA IF NOT EXISTS inventory;

--- a/examples/axum/src/db/migrations/20240530135613_create_tables_categories_and_products.down.sql
+++ b/examples/axum/src/db/migrations/20240530135613_create_tables_categories_and_products.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS inventory.products;
+
+DROP TABLE IF EXISTS inventory.categories;

--- a/examples/axum/src/db/migrations/20240530135613_create_tables_categories_and_products.up.sql
+++ b/examples/axum/src/db/migrations/20240530135613_create_tables_categories_and_products.up.sql
@@ -1,0 +1,33 @@
+-- Add up migration script here
+CREATE TABLE IF NOT EXISTS inventory.categories (
+	id UUID default uuid_generate_v1() PRIMARY KEY NOT NULL,
+	name VARCHAR(255) NOT NULL UNIQUE,
+	created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE inventory.categories IS 'This table stores product categories.';
+COMMENT ON COLUMN inventory.categories.id IS 'Unique identifier for the category.';
+COMMENT ON COLUMN inventory.categories.name IS 'Name of the category.';
+COMMENT ON COLUMN inventory.categories.created_at IS 'Timestamp when the category was created.';
+
+CREATE TABLE IF NOT EXISTS inventory.products (
+	id UUID default uuid_generate_v1() PRIMARY KEY NOT NULL,
+	name VARCHAR(255) NOT NULL UNIQUE,
+	description VARCHAR NOT NULL,
+	quantity INT NOT NULL,
+	unitary_price FLOAT NOT NULL,
+	category_id UUID NOT NULL,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMPTZ,
+	foreign key (category_id) references inventory.categories(id)
+);
+
+COMMENT ON TABLE inventory.products IS 'This table stores products and their related information.';
+COMMENT ON COLUMN inventory.products.id IS 'Unique identifier for the product.';
+COMMENT ON COLUMN inventory.products.name IS 'Name of the product.';
+COMMENT ON COLUMN inventory.products.description IS 'Description of the product.';
+COMMENT ON COLUMN inventory.products.quantity IS 'Quantity of the product in stock.';
+COMMENT ON COLUMN inventory.products.unitary_price IS 'Unit price of the product.';
+COMMENT ON COLUMN inventory.products.category_id IS 'Category ID the product belongs to.';
+COMMENT ON COLUMN inventory.products.created_at IS 'Timestamp when the product was created.';
+COMMENT ON COLUMN inventory.products.updated_at IS 'Timestamp when the product was last updated.';

--- a/examples/axum/src/db/migrations/20240530141545_populate_inventory.down.sql
+++ b/examples/axum/src/db/migrations/20240530141545_populate_inventory.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+DELETE FROM inventory.products;
+
+DELETE FROM inventory.categories;

--- a/examples/axum/src/db/migrations/20240530141545_populate_inventory.up.sql
+++ b/examples/axum/src/db/migrations/20240530141545_populate_inventory.up.sql
@@ -1,0 +1,24 @@
+-- Add up migration script here
+-- Populate categories table:
+INSERT INTO inventory.categories (id, name) 
+VALUES 
+    ('17801a41-0f97-46d1-809f-2fa3e301f9ea', 'Fresh Produce'), 
+    ('8980d63e-7e1d-4b6e-97d8-67e7adbd473e', 'Dairy & Eggs'), 
+    ('58740dc5-0b52-45c9-a3b1-a852a1e6f03d', 'Meat & Seafood'),
+    ('023366b8-fc36-41ed-978a-a1c5856a08eb', 'Bakery')
+ON CONFLICT DO NOTHING;
+
+-- Populate products table:
+INSERT INTO inventory.products (name, description, quantity, unitary_price, category_id)
+VALUES
+	('Apples', 'Fresh apples', 100, 0.5, '17801a41-0f97-46d1-809f-2fa3e301f9ea'),
+	('Oranges', 'Fresh oranges', 80, 0.6, '17801a41-0f97-46d1-809f-2fa3e301f9ea'),
+	('Milk', '1L milk', 50, 1.2, '8980d63e-7e1d-4b6e-97d8-67e7adbd473e'),
+	('Cheese', 'Cheddar cheese', 30, 2.5, '8980d63e-7e1d-4b6e-97d8-67e7adbd473e'),
+	('Chicken', 'Fresh chicken', 20, 5.0, '58740dc5-0b52-45c9-a3b1-a852a1e6f03d'),
+	('Fish', 'Fresh fish', 15, 7.0, '58740dc5-0b52-45c9-a3b1-a852a1e6f03d'),
+	('Bread', 'Fresh bread', 100, 1.0, '023366b8-fc36-41ed-978a-a1c5856a08eb'),
+	('Croissant', 'Fresh croissant', 50, 1.5, '023366b8-fc36-41ed-978a-a1c5856a08eb'),
+	('Eggs', 'Dozen eggs', 40, 2.0, '8980d63e-7e1d-4b6e-97d8-67e7adbd473e'),
+	('Butter', '500g butter', 30, 2.5, '8980d63e-7e1d-4b6e-97d8-67e7adbd473e')
+ON CONFLICT DO NOTHING;

--- a/examples/axum/src/db/migrations/20240530142352_populate_inventory.down.sql
+++ b/examples/axum/src/db/migrations/20240530142352_populate_inventory.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/examples/axum/src/db/migrations/20240530142352_populate_inventory.up.sql
+++ b/examples/axum/src/db/migrations/20240530142352_populate_inventory.up.sql
@@ -1,0 +1,1 @@
+-- Add up migration script here

--- a/examples/axum/src/db/mod.rs
+++ b/examples/axum/src/db/mod.rs
@@ -1,0 +1,2 @@
+pub mod handler;
+pub mod repository;

--- a/examples/axum/src/db/repository/categories.rs
+++ b/examples/axum/src/db/repository/categories.rs
@@ -1,0 +1,82 @@
+use log::debug;
+use page_hunter::{PaginationResult, SqlxPagination};
+use sqlx::{Error as SqlxError, FromRow, PgPool, Postgres, QueryBuilder};
+use std::future::Future;
+use uuid::Uuid;
+
+use crate::db::handler::Repository;
+
+use crate::models::categories::{Category, PaginatedCategories, SearchCategoriesRequest};
+
+pub trait CategoriesRepositoryMethods {
+    fn get_category_by_id(&self, id: Uuid) -> impl Future<Output = Result<Category, SqlxError>>;
+
+    fn list_categories(
+        &self,
+        search_by: &SearchCategoriesRequest,
+    ) -> impl Future<Output = PaginationResult<PaginatedCategories>>;
+}
+
+pub struct CategoriesRepository<'p> {
+    pool: &'p PgPool,
+}
+
+impl<'p> Repository<'p> for CategoriesRepository<'p> {
+    fn get_pool(&self) -> &'p PgPool {
+        self.pool
+    }
+
+    fn new(pool: &'p PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl<'p> CategoriesRepositoryMethods for CategoriesRepository<'p> {
+    async fn get_category_by_id(&self, id: Uuid) -> Result<Category, SqlxError> {
+        Ok(Category::from_row(
+            &QueryBuilder::<Postgres>::new(format!(
+                r#"SELECT
+						*
+					FROM
+						inventory.categories
+					WHERE
+						1=1
+						AND id = '{}';
+				"#,
+                id
+            ))
+            .build()
+            .fetch_one(self.get_pool())
+            .await?,
+        )?)
+    }
+
+    async fn list_categories(
+        &self,
+        search_by: &SearchCategoriesRequest,
+    ) -> PaginationResult<PaginatedCategories> {
+        let mut query: QueryBuilder<Postgres> = QueryBuilder::<Postgres>::new(
+            r#"SELECT
+				*
+			FROM
+				inventory.categories
+			WHERE
+				1=1
+			"#,
+        );
+
+        match search_by.get_name_like() {
+            Some(name_like) => {
+                debug!("filtering by name_like: {}", name_like);
+                query.push(format!("AND LOWER(name) ILIKE '%{name_like}%'"));
+            }
+            None => debug!("No name_like provided"),
+        }
+
+        let categories: PaginatedCategories = query
+            .paginate(self.get_pool(), search_by.get_page(), search_by.get_size())
+            .await?;
+
+        Ok(categories)
+    }
+}

--- a/examples/axum/src/db/repository/categories.rs
+++ b/examples/axum/src/db/repository/categories.rs
@@ -1,5 +1,5 @@
 use log::debug;
-use page_hunter::{PaginationResult, SqlxPagination};
+use page_hunter::{PaginationResult, SQLxPagination};
 use sqlx::{Error as SqlxError, FromRow, PgPool, Postgres, QueryBuilder};
 use std::future::Future;
 use uuid::Uuid;

--- a/examples/axum/src/db/repository/mod.rs
+++ b/examples/axum/src/db/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod categories;
+pub mod products;

--- a/examples/axum/src/db/repository/products.rs
+++ b/examples/axum/src/db/repository/products.rs
@@ -1,0 +1,219 @@
+use log::debug;
+use page_hunter::{Page, PaginationResult, SqlxPagination};
+use sqlx::{Error as SqlxError, FromRow, PgPool, Postgres, QueryBuilder};
+use std::future::Future;
+use uuid::Uuid;
+
+use crate::db::handler::Repository;
+
+use crate::models::products::{
+    CreateProductRequest, PaginatedProducts, PaginatedProductsBase, Product, ProductBase,
+    ProductId, SearchProductsRequest, UpdateProductQuantityRequest,
+};
+
+pub trait ProductsRepositoryMethods {
+    fn get_product_by_id(&self, id: Uuid) -> impl Future<Output = Result<Product, SqlxError>>;
+
+    fn list_products(
+        &self,
+        search_by: &SearchProductsRequest,
+    ) -> impl Future<Output = PaginationResult<PaginatedProducts>>;
+
+    fn delete_product(&self, id: Uuid) -> impl Future<Output = Result<ProductId, SqlxError>>;
+
+    fn create_product(
+        &self,
+        product: &CreateProductRequest,
+    ) -> impl Future<Output = Result<ProductId, SqlxError>>;
+
+    fn update_product_quantity(
+        &self,
+        id: Uuid,
+        update_by: &UpdateProductQuantityRequest,
+    ) -> impl Future<Output = Result<ProductId, SqlxError>>;
+}
+
+pub struct ProductsRepository<'p> {
+    pool: &'p PgPool,
+}
+
+impl<'p> Repository<'p> for ProductsRepository<'p> {
+    fn get_pool(&self) -> &'p PgPool {
+        self.pool
+    }
+
+    fn new(pool: &'p PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl<'p> ProductsRepositoryMethods for ProductsRepository<'p> {
+    async fn get_product_by_id(&self, id: Uuid) -> Result<Product, SqlxError> {
+        Ok(Product::from(ProductBase::from_row(
+            &QueryBuilder::<Postgres>::new(format!(
+                r#"SELECT
+						p.*,
+						c.id AS category_id,
+						c.name AS category_name,
+						c.created_at AS category_created_at
+					FROM
+						inventory.products p
+					INNER JOIN inventory.categories c ON
+						p.category_id = c.id
+					WHERE
+						p.id = '{}';
+				"#,
+                id
+            ))
+            .build()
+            .fetch_one(self.get_pool())
+            .await?,
+        )?))
+    }
+
+    async fn list_products(
+        &self,
+        search_by: &SearchProductsRequest,
+    ) -> PaginationResult<PaginatedProducts> {
+        let mut query: QueryBuilder<Postgres> = QueryBuilder::<Postgres>::new(
+            r#"SELECT
+				p.*,
+				c.id AS category_id,
+				c.name AS category_name,
+				c.created_at AS category_created_at
+			FROM
+				inventory.products p
+			INNER JOIN inventory.categories c ON
+				p.category_id = c.id
+			WHERE
+				1=1
+			"#,
+        );
+
+        match search_by.get_name_like() {
+            Some(name_like) => {
+                debug!("filtering by name_like: {}", name_like);
+                query.push(format!("AND LOWER(p.name) ILIKE '%{name_like}%'"));
+            }
+            None => debug!("No name_like provided"),
+        }
+
+        match search_by.get_description_like() {
+            Some(description_like) => {
+                debug!("filtering by description_like: {}", description_like);
+                query.push(format!(
+                    "AND LOWER(p.description) ILIKE '%{description_like}%'"
+                ));
+            }
+            None => debug!("No description_like provided"),
+        }
+
+        match search_by.get_category_id() {
+            Some(category_id) => {
+                debug!("filtering by category_id: {}", category_id);
+                query.push(format!("AND category_id = '{}'", category_id));
+            }
+            None => debug!("No category_id provided"),
+        }
+
+        match search_by.get_category_name_like() {
+            Some(category_name_like) => {
+                debug!("filtering by category_name_like: {}", category_name_like);
+                query.push(format!("AND LOWER(c.name) ILIKE '%{category_name_like}%'"));
+            }
+            None => debug!("No category_name_like provided"),
+        }
+
+        let products_base: PaginatedProductsBase = query
+            .paginate(self.get_pool(), search_by.get_page(), search_by.get_size())
+            .await?;
+
+        let products: PaginatedProducts = Page::new(
+            &products_base
+                .clone()
+                .into_iter()
+                .map(|product_base| Product::from(product_base))
+                .collect::<Vec<Product>>(),
+            products_base.get_page(),
+            products_base.get_size(),
+            products_base.get_total(),
+        )?;
+
+        Ok(products)
+    }
+
+    async fn delete_product(&self, id: Uuid) -> Result<ProductId, SqlxError> {
+        Ok(ProductId::from_row(
+            &QueryBuilder::<Postgres>::new(format!(
+                r#"
+				DELETE FROM
+					inventory.products p
+				WHERE 
+					p.id = '{}'
+				RETURNING
+					p.id;
+			"#,
+                id
+            ))
+            .build()
+            .fetch_one(self.get_pool())
+            .await?,
+        )?)
+    }
+
+    async fn create_product(&self, product: &CreateProductRequest) -> Result<ProductId, SqlxError> {
+        Ok(ProductId::from_row(
+            &QueryBuilder::<Postgres>::new(format!(
+                r#"
+				INSERT INTO inventory.products (
+					name,
+					description,
+					quantity,
+					unitary_price,
+					category_id
+				) VALUES (
+					'{name}',
+					'{description}',
+					{quantity},
+					{unitary_price},
+					'{category_id}'
+				) RETURNING 
+					id;
+			"#,
+                name = product.get_name(),
+                description = product.get_description(),
+                quantity = product.get_quantity(),
+                unitary_price = product.get_unitary_price(),
+                category_id = product.get_category_id()
+            ))
+            .build()
+            .fetch_one(self.get_pool())
+            .await?,
+        )?)
+    }
+
+    async fn update_product_quantity(
+        &self,
+        id: Uuid,
+        update_by: &UpdateProductQuantityRequest,
+    ) -> Result<ProductId, SqlxError> {
+        Ok(ProductId::from_row(
+            &QueryBuilder::<Postgres>::new(format!(
+                r#"
+				UPDATE
+					inventory.products p
+				SET
+					quantity = {quantity}
+				WHERE
+					p.id = '{id}'
+				RETURNING
+					p.id;
+			"#,
+                quantity = update_by.get_quantity(),
+            ))
+            .build()
+            .fetch_one(self.get_pool())
+            .await?,
+        )?)
+    }
+}

--- a/examples/axum/src/db/repository/products.rs
+++ b/examples/axum/src/db/repository/products.rs
@@ -1,5 +1,5 @@
 use log::debug;
-use page_hunter::{Page, PaginationResult, SqlxPagination};
+use page_hunter::{Page, PaginationResult, SQLxPagination};
 use sqlx::{Error as SqlxError, FromRow, PgPool, Postgres, QueryBuilder};
 use std::future::Future;
 use uuid::Uuid;

--- a/examples/axum/src/docs/mod.rs
+++ b/examples/axum/src/docs/mod.rs
@@ -1,0 +1,1 @@
+pub mod open_api;

--- a/examples/axum/src/docs/open_api.rs
+++ b/examples/axum/src/docs/open_api.rs
@@ -1,0 +1,38 @@
+use utoipa::OpenApi;
+
+use crate::api::routes::categories::{__path_get_category_by_id, __path_list_categories};
+use crate::api::routes::products::{
+    __path_create_product, __path_delete_product, __path_get_product_by_id, __path_list_products,
+    __path_update_product_quantity,
+};
+
+use crate::models::categories::{Category, PaginatedCategories};
+use crate::models::errors::HttpException;
+use crate::models::products::{
+    CreateProductRequest, PaginatedProducts, Product, ProductId, UpdateProductQuantityRequest,
+};
+
+#[derive(OpenApi)]
+#[openapi(
+    info(title = "Supermarket Inventory Manager"),
+    paths(
+        get_category_by_id,
+        list_categories,
+        create_product,
+        get_product_by_id,
+        list_products,
+        delete_product,
+        update_product_quantity,
+    ),
+    components(schemas(
+        Category,
+        PaginatedCategories,
+        CreateProductRequest,
+        Product,
+        UpdateProductQuantityRequest,
+        PaginatedProducts,
+        ProductId,
+        HttpException
+    ))
+)]
+pub struct ApiDoc;

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -1,0 +1,51 @@
+use axum::{serve as axum_serve, Extension};
+use log::info;
+use sqlx::postgres::PgPool;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+mod api;
+use api::router::{ApiRouter, ServiceRouter};
+
+mod config;
+use config::conf::Conf;
+use config::logconfig::LogConfig;
+
+mod db;
+use db::handler::DbHandler;
+
+mod docs;
+
+mod models;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let settings: Conf = Conf::get();
+    let db_handler: DbHandler = DbHandler::new();
+
+    LogConfig::init_logger(settings.get_server_config().get_log_level());
+
+    info!("Initializing database connection and running migrations");
+
+    let pool: PgPool = db_handler.get_pool(&settings.get_database_config()).await?;
+    db_handler.run_migrations(&pool).await?;
+
+    info!("Database connection and migrations completed successfully");
+
+    info!(
+        "Starting service: {}",
+        settings.get_server_config().get_name()
+    );
+    info!(
+        "Listening on: {:?}",
+        settings.get_server_config().get_service_address()
+    );
+
+    Ok(axum_serve(
+        TcpListener::bind(settings.get_server_config().get_service_address()).await?,
+        ApiRouter::new()
+            .get_router()
+            .layer(Extension(Arc::new(pool))),
+    )
+    .await?)
+}

--- a/examples/axum/src/models/categories.rs
+++ b/examples/axum/src/models/categories.rs
@@ -1,0 +1,47 @@
+use page_hunter::Page;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use time::{serde::rfc3339, OffsetDateTime};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SearchCategoriesRequest {
+    name_like: Option<String>,
+    page: Option<usize>,
+    size: Option<usize>,
+}
+
+impl SearchCategoriesRequest {
+    pub fn get_name_like(&self) -> &Option<String> {
+        &self.name_like
+    }
+
+    pub fn get_page(&self) -> usize {
+        self.page.unwrap_or(0)
+    }
+
+    pub fn get_size(&self) -> usize {
+        self.size.unwrap_or(50)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, FromRow, ToSchema)]
+pub struct Category {
+    id: Uuid,
+    name: String,
+    #[serde(with = "rfc3339")]
+    created_at: OffsetDateTime,
+}
+
+impl Category {
+    pub fn new(id: Uuid, name: String, created_at: OffsetDateTime) -> Self {
+        Self {
+            id,
+            name,
+            created_at,
+        }
+    }
+}
+
+pub type PaginatedCategories = Page<Category>;

--- a/examples/axum/src/models/errors.rs
+++ b/examples/axum/src/models/errors.rs
@@ -1,0 +1,76 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use page_hunter::{ErrorKind, PaginationError};
+use serde::Serialize;
+use sqlx::Error as SqlxError;
+use utoipa::ToSchema;
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct HttpException {
+    #[serde(skip)]
+    status_code: StatusCode,
+    details: String,
+}
+
+impl HttpException {
+    pub fn get_status_code(&self) -> StatusCode {
+        self.status_code
+    }
+
+    pub fn get_details(&self) -> &str {
+        &self.details
+    }
+
+    pub fn internal_server_error(details: &str) -> Self {
+        Self {
+            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            details: format!("Internal server error: {details}"),
+        }
+    }
+
+    pub fn not_found(details: &str) -> Self {
+        Self {
+            status_code: StatusCode::NOT_FOUND,
+            details: format!("Not found: {details}"),
+        }
+    }
+}
+
+impl From<HttpException> for Response {
+    fn from(error: HttpException) -> Self {
+        (error.get_status_code(), Json(error)).into_response()
+    }
+}
+
+impl From<SqlxError> for HttpException {
+    fn from(error: SqlxError) -> Self {
+        let status_code: StatusCode = match error {
+            SqlxError::RowNotFound => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+        Self {
+            status_code,
+            details: format!(
+                "{description}: {error}",
+                description = status_code.to_string()
+            ),
+        }
+    }
+}
+
+impl From<PaginationError> for HttpException {
+    fn from(error: PaginationError) -> Self {
+        match error.get_error_kind() {
+            ErrorKind::FieldValueError(details) => Self::internal_server_error(details),
+
+            ErrorKind::SQLxError(error) => match error {
+                SqlxError::RowNotFound => Self::not_found(&error.to_string()),
+                _ => Self::internal_server_error(&error.to_string()),
+            },
+        }
+    }
+}

--- a/examples/axum/src/models/mod.rs
+++ b/examples/axum/src/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod categories;
+pub mod errors;
+pub mod products;

--- a/examples/axum/src/models/products.rs
+++ b/examples/axum/src/models/products.rs
@@ -1,0 +1,213 @@
+use page_hunter::Page;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use time::{serde::rfc3339, OffsetDateTime};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use crate::models::categories::Category;
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SearchProductsRequest {
+    name_like: Option<String>,
+    description_like: Option<String>,
+    category_id: Option<Uuid>,
+    category_name_like: Option<String>,
+    page: Option<usize>,
+    size: Option<usize>,
+}
+
+impl SearchProductsRequest {
+    pub fn get_name_like(&self) -> &Option<String> {
+        &self.name_like
+    }
+
+    pub fn get_description_like(&self) -> &Option<String> {
+        &self.description_like
+    }
+
+    pub fn get_category_id(&self) -> Option<Uuid> {
+        self.category_id
+    }
+
+    pub fn get_category_name_like(&self) -> &Option<String> {
+        &self.category_name_like
+    }
+
+    pub fn get_page(&self) -> usize {
+        self.page.unwrap_or(0)
+    }
+
+    pub fn get_size(&self) -> usize {
+        self.size.unwrap_or(50)
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateProductRequest {
+    name: String,
+    description: String,
+    quantity: i32,
+    unitary_price: f64,
+    category_id: Uuid,
+}
+
+impl CreateProductRequest {
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn get_quantity(&self) -> i32 {
+        self.quantity
+    }
+
+    pub fn get_unitary_price(&self) -> f64 {
+        self.unitary_price
+    }
+
+    pub fn get_category_id(&self) -> Uuid {
+        self.category_id
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateProductQuantityRequest {
+    quantity: i32,
+}
+
+impl UpdateProductQuantityRequest {
+    pub fn get_quantity(&self) -> i32 {
+        self.quantity
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct ProductBase {
+    id: Uuid,
+    name: String,
+    description: String,
+    quantity: i32,
+    unitary_price: f64,
+    created_at: OffsetDateTime,
+    updated_at: Option<OffsetDateTime>,
+    category_id: Uuid,
+    category_name: String,
+    category_created_at: OffsetDateTime,
+}
+
+impl ProductBase {
+    pub fn get_id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn get_quantity(&self) -> i32 {
+        self.quantity
+    }
+
+    pub fn get_unitary_price(&self) -> f64 {
+        self.unitary_price
+    }
+
+    pub fn get_created_at(&self) -> OffsetDateTime {
+        self.created_at
+    }
+
+    pub fn get_updated_at(&self) -> Option<OffsetDateTime> {
+        self.updated_at
+    }
+
+    pub fn get_category_id(&self) -> Uuid {
+        self.category_id
+    }
+
+    pub fn get_category_name(&self) -> &str {
+        &self.category_name
+    }
+
+    pub fn get_category_created_at(&self) -> OffsetDateTime {
+        self.category_created_at
+    }
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct Product {
+    id: Uuid,
+    name: String,
+    description: String,
+    quantity: i32,
+    unitary_price: f64,
+    #[serde(with = "rfc3339")]
+    created_at: OffsetDateTime,
+    #[serde(with = "rfc3339::option")]
+    updated_at: Option<OffsetDateTime>,
+    category: Category,
+}
+
+impl Product {
+    pub fn new(
+        id: Uuid,
+        name: String,
+        description: String,
+        quantity: i32,
+        unitary_price: f64,
+        created_at: OffsetDateTime,
+        updated_at: Option<OffsetDateTime>,
+        category: Category,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            description,
+            quantity,
+            unitary_price,
+            created_at,
+            updated_at,
+            category,
+        }
+    }
+}
+
+impl From<ProductBase> for Product {
+    fn from(product_base: ProductBase) -> Self {
+        Self::new(
+            product_base.get_id(),
+            product_base.get_name().to_owned(),
+            product_base.get_description().to_owned(),
+            product_base.get_quantity(),
+            product_base.get_unitary_price(),
+            product_base.get_created_at(),
+            product_base.get_updated_at(),
+            Category::new(
+                product_base.get_category_id(),
+                product_base.get_category_name().to_owned(),
+                product_base.get_category_created_at(),
+            ),
+        )
+    }
+}
+
+pub type PaginatedProductsBase = Page<ProductBase>;
+pub type PaginatedProducts = Page<Product>;
+
+#[derive(Debug, Serialize, FromRow, ToSchema)]
+pub struct ProductId {
+    id: Uuid,
+}
+
+impl ProductId {
+    pub fn get_id(&self) -> Uuid {
+        self.id
+    }
+}

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🧑🏻‍💻 Implement `ErrorKind::SQLxError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
 - 🧑🏻‍💻 Implement `is_sqlx_error()` method for `ErrorKind` according to its new structure  when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
 - 🧑🏻‍💻 Implement **From**<**sqlx::Error**> for `PaginationError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled. 
+- 🧑🏻‍💻  Including example of use with **axum**.
 
 ### Changed:
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🧑🏻‍💻 Implement **utoipa::ToSchema** for `Page` and `Book`.  Only available when ***utoipa*** feature is enabled.
 - 🧑🏻‍💻 Implement examples folder.
+- 🧑🏻‍💻 Including example of use with **actix-web**.
 
 ### Fixed:
 

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - 🔨 **Derive** and **Display** implementations for `PaginationError` and `ErrorKind` according to the new `ErrorKind` structure **[BREAKING CHANGE]**.
+- 🔨 Rename `SqlxPagination` to `SQLxPagination` **[BREAKING CHANGE]**.
 
 ### Removed:
 

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 🚀 v0.2.0 [2024-XX-XX]
+
+### Added:
+
+- 🧑🏻‍💻 Implement `ErrorKind::SQLxError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
+- 🧑🏻‍💻 Implement `is_sqlx_error()` method for `ErrorKind` according to its new structure  when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
+- 🧑🏻‍💻 Implement **From**<**sqlx::Error**> for `PaginationError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled. 
+
+### Changed:
+
+- 🔨 **Derive** and **Display** implementations for `PaginationError` and `ErrorKind` according to the new `ErrorKind` structure **[BREAKING CHANGE]**.
+
+### Removed:
+
+- ❌ Remove `ErrorKind::DatabaseError` and `ErrorKind::FromRowError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
+- ❌ Remove `is_database_error()` and `is_from_row_error()` methods from `ErrorKind` according to its new structure **[BREAKING CHANGE]**.
+- ❌ Remove **Clone** implementation for `PaginationError` and `ErrorKind` **[BREAKING CHANGE]**.
+
 ## 🚀 v0.1.4 [2024-05-29]
 
 ### Added:
@@ -30,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🧑🏻‍💻 Implement `SqlxPagination` for `QueryBuilder<MySQL>` to paginate results from a SQL query into a `Page`. Only available when ***mysql-sqlx*** feature is enabled.
 - 🧑🏻‍💻 Implement `SqlxPagination` for `QueryBuilder<Postgres>` to paginate results from a SQL query into a `Page`. Only available when ***pg-sqlx*** feature is enabled.
 - 🧑🏻‍💻 Implement integration test for pagination with ***mysql-sqlx***.
-
 
 ### Changed:
 

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "page-hunter"
 description = "The pagination powerhouse, built with Rust"
-version = "0.1.4"
+version = "0.2.0"
 authors = [
     "Juan Manuel Tamayo <jmtamayog23@gmail.com>",
 ]
@@ -23,10 +23,11 @@ categories = [
 [dependencies]
 serde = { version = "1.0.203", features = ["derive"],  optional = true }
 utoipa = { version = "4.2.3", optional = true}
-sqlx = { version = "0.7.4", features = ["runtime-tokio", "uuid", "time", "chrono", "json", "postgres", "mysql"], optional = true }
+sqlx = { version = "0.7.4", features = ["runtime-tokio", "postgres", "mysql"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.37.0", features =["full"] }
+sqlx = { version = "0.7.4", features = ["uuid", "time"] }
+tokio = { version = "1.38.0", features =["full"] }
 serde_json = { version = "1.0.117" }
 uuid = { version = "1.8.0" }
 time = { version = "0.3.36" }

--- a/page-hunter/src/lib.rs
+++ b/page-hunter/src/lib.rs
@@ -8,14 +8,14 @@
 //!
 //! ```ini
 //! [dependencies]
-//! page-hunter = {git = "https://github.com/JMTamayo/page-hunter.git", version = "0.1.4", features = ["serde"] }
+//! page-hunter = { git = "https://github.com/JMTamayo/page-hunter.git", version = "0.2.0", features = ["serde"] }
 //! ```
 //!
 //! You can depend on it via cargo by adding the following dependency to your `Cargo.toml` file:
 //!
 //! ```ini
 //! [dependencies]
-//! page-hunter = { version = "0.1.4", features = ["utoipa", "pg-sqlx"] }
+//! page-hunter = { version = "0.2.0", features = ["utoipa", "pg-sqlx"] }
 //! ```
 //!
 //! ## CRATE FEATURES

--- a/page-hunter/src/page_hunter/sqlx_pagination.rs
+++ b/page-hunter/src/page_hunter/sqlx_pagination.rs
@@ -12,7 +12,7 @@ use sqlx::postgres::{PgPool, PgRow, Postgres};
 
 /// Trait to paginate results from a SQL query into a [`Page`] model from database using [`sqlx`].
 #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
-pub trait SqlxPagination<DB, S>
+pub trait SQLxPagination<DB, S>
 where
     DB: Database,
     S: for<'r> FromRow<'r, DB::Row> + Clone,
@@ -105,7 +105,7 @@ where
 ///
 /// Only available when the `mysql-sqlx` feature is enabled.
 #[cfg(feature = "mysql-sqlx")]
-impl<'q, S> SqlxPagination<MySql, S> for QueryBuilder<'q, MySql>
+impl<'q, S> SQLxPagination<MySql, S> for QueryBuilder<'q, MySql>
 where
     S: for<'r> FromRow<'r, MySqlRow> + Clone,
 {
@@ -214,7 +214,7 @@ where
 ///
 /// Only available when the `pg-sqlx` feature is enabled.
 #[cfg(feature = "pg-sqlx")]
-impl<'q, S> SqlxPagination<Postgres, S> for QueryBuilder<'q, Postgres>
+impl<'q, S> SQLxPagination<Postgres, S> for QueryBuilder<'q, Postgres>
 where
     S: for<'r> FromRow<'r, PgRow> + Clone,
 {

--- a/page-hunter/tests/test_sqlx_pagination.rs
+++ b/page-hunter/tests/test_sqlx_pagination.rs
@@ -125,8 +125,7 @@ pub mod test_postgres_pagination {
         let error: String = users_pagination.unwrap_err().to_string();
         assert_eq!(
             error,
-            "SQLX ERROR- error returned from database: syntax error at or near \";\""
-                .to_string(),
+            "SQLX ERROR- error returned from database: syntax error at or near \";\"".to_string(),
         )
     }
 

--- a/page-hunter/tests/test_sqlx_pagination.rs
+++ b/page-hunter/tests/test_sqlx_pagination.rs
@@ -125,7 +125,7 @@ pub mod test_postgres_pagination {
         let error: String = users_pagination.unwrap_err().to_string();
         assert_eq!(
             error,
-            "DATABASE ERROR- error returned from database: syntax error at or near \";\""
+            "SQLX ERROR- error returned from database: syntax error at or near \";\""
                 .to_string(),
         )
     }
@@ -179,7 +179,7 @@ pub mod test_postgres_pagination {
         let error: String = users_pagination.unwrap_err().to_string();
         assert_eq!(
             error,
-            "FROM ROW ERROR- no column found for name: age".to_string(),
+            "SQLX ERROR- no column found for name: age".to_string(),
         )
     }
 
@@ -356,7 +356,7 @@ pub mod test_mysql_pagination {
         let error: String = users_pagination.unwrap_err().to_string();
         assert_eq!(
             error,
-            "DATABASE ERROR- error returned from database: 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ';) as temp_table' at line 1"
+            "SQLX ERROR- error returned from database: 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ';) as temp_table' at line 1"
                 .to_string(),
         )
     }
@@ -407,7 +407,7 @@ pub mod test_mysql_pagination {
         let error: String = users_pagination.unwrap_err().to_string();
         assert_eq!(
             error,
-            "FROM ROW ERROR- no column found for name: extension".to_string(),
+            "SQLX ERROR- no column found for name: extension".to_string(),
         )
     }
 


### PR DESCRIPTION
### Added:

- Implement `ErrorKind::SQLxError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
- Implement `is_sqlx_error()` method for `ErrorKind` according to its new structure  when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
- Implement **From**<**sqlx::Error**> for `PaginationError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled. 
-  Including example of use with **axum**.

### Changed:

- **Derive** and **Display** implementations for `PaginationError` and `ErrorKind` according to the new `ErrorKind` structure **[BREAKING CHANGE]**.
- Rename `SqlxPagination` to `SQLxPagination` **[BREAKING CHANGE]**.

### Removed:

- Remove `ErrorKind::DatabaseError` and `ErrorKind::FromRowError` when ***mysql-sqlx*** or ***pg-sqlx*** features are enabled **[BREAKING CHANGE]**.
- Remove `is_database_error()` and `is_from_row_error()` methods from `ErrorKind` according to its new structure **[BREAKING CHANGE]**.
- Remove **Clone** implementation for `PaginationError` and `ErrorKind` **[BREAKING CHANGE]**.
