### PR TITLE
feat: sqlite-sqlx feature

### DIFF
--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -2,32 +2,27 @@
 name = "page-hunter"
 description = "The pagination powerhouse, built with Rust"
 version = "0.2.0"
-authors = [
-    "Juan Manuel Tamayo <jmtamayog23@gmail.com>",
-]
+authors = ["Juan Manuel Tamayo <jmtamayog23@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/jmtamayo/page-hunter"
 documentation = "https://docs.rs/page-hunter"
 homepage = "https://github.com/jmtamayo/page-hunter"
 license-file = "../LICENSE"
 readme = "../README.md"
-keywords = [
-    "pagination",
-    "paginator",
-    "page_model"
-]
-categories = [
-    "development-tools",
-]
+keywords = ["pagination", "paginator", "page_model"]
+categories = ["development-tools"]
 
 [dependencies]
-serde = { version = "1.0.203", features = ["derive"],  optional = true }
-utoipa = { version = "4.2.3", optional = true}
-sqlx = { version = "0.7.4", features = ["runtime-tokio", "postgres", "mysql"], optional = true }
+serde = { version = "1.0.203", features = ["derive"], optional = true }
+utoipa = { version = "4.2.3", optional = true }
+sqlx = { version = ">= 0.7.4", features = [
+    "runtime-tokio",
+], optional = true } # Disable default features for sqlx
+
 
 [dev-dependencies]
 sqlx = { version = "0.7.4", features = ["uuid", "time"] }
-tokio = { version = "1.38.0", features =["full"] }
+tokio = { version = "1.38.0", features = ["full"] }
 serde_json = { version = "1.0.117" }
 uuid = { version = "1.8.0" }
 time = { version = "0.3.36" }
@@ -35,8 +30,9 @@ time = { version = "0.3.36" }
 [features]
 serde = ["dep:serde"]
 utoipa = ["dep:utoipa", "serde"]
-pg-sqlx = ["dep:sqlx"]
-mysql-sqlx = ["dep:sqlx"]
+pg-sqlx = ["dep:sqlx", "sqlx/postgres"]
+mysql-sqlx = ["dep:sqlx", "sqlx/mysql"]
+sqlite-sqlx = ["dep:sqlx", "sqlx/sqlite"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/page-hunter/src/lib.rs
+++ b/page-hunter/src/lib.rs
@@ -249,5 +249,5 @@ pub use page_hunter::errors::*;
 pub use page_hunter::models::*;
 pub use page_hunter::records_pagination::*;
 
-#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
 pub use page_hunter::sqlx_pagination::*;

--- a/page-hunter/src/page_hunter/errors.rs
+++ b/page-hunter/src/page_hunter/errors.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter, Result};
 #[allow(unused_imports)]
 use super::models::Page;
 
-#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
 use sqlx::Error as SqlxError;
 
 /// Provides a way to categorize the pagination error.
@@ -12,7 +12,7 @@ pub enum ErrorKind {
     FieldValueError(String),
 
     /// Raised during a database operation using the [`sqlx`]. Only available when the `pg-sqlx` or `mysql-sqlx` features are enabled.
-    #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+    #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
     SQLxError(SqlxError),
 }
 
@@ -23,7 +23,7 @@ impl ErrorKind {
     }
 
     /// Check if the [`ErrorKind`] is a [`ErrorKind::SQLxError`]. Only available when the `pg-sqlx` or `mysql-sqlx` features are enabled.
-    #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+    #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
     pub fn is_sqlx_error(&self) -> bool {
         matches!(self, ErrorKind::SQLxError(_))
     }
@@ -35,7 +35,7 @@ impl Display for ErrorKind {
         match self {
             ErrorKind::FieldValueError(detail) => write!(f, "FIELD VALUE ERROR- {}", detail),
 
-            #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+            #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
             ErrorKind::SQLxError(detail) => write!(f, "SQLX ERROR- {}", detail),
         }
     }
@@ -47,7 +47,7 @@ impl Debug for ErrorKind {
         match self {
             ErrorKind::FieldValueError(detail) => write!(f, "FieldValueError({:?})", detail),
 
-            #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+            #[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
             ErrorKind::SQLxError(detail) => write!(f, "SqlxError({:?})", detail),
         }
     }
@@ -87,7 +87,7 @@ impl From<ErrorKind> for PaginationError {
 }
 
 /// Implementation of [`From`]<[`sqlx::Error`]> for [`PaginationError`]. Only available when the `pg-sqlx` or `mysql-sqlx` features are enabled.
-#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
 impl From<SqlxError> for PaginationError {
     fn from(value: sqlx::Error) -> Self {
         Self {

--- a/page-hunter/src/page_hunter/sqlx_pagination.rs
+++ b/page-hunter/src/page_hunter/sqlx_pagination.rs
@@ -1,7 +1,7 @@
-#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
 use super::models::{Page, PaginationResult};
 
-#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
 use sqlx::{query, query_builder::QueryBuilder, query_scalar, Database, FromRow, Pool};
 
 #[cfg(feature = "mysql-sqlx")]

--- a/page-hunter/src/page_hunter/sqlx_pagination.rs
+++ b/page-hunter/src/page_hunter/sqlx_pagination.rs
@@ -10,8 +10,11 @@ use sqlx::mysql::{MySql, MySqlPool, MySqlRow};
 #[cfg(feature = "pg-sqlx")]
 use sqlx::postgres::{PgPool, PgRow, Postgres};
 
+#[cfg(feature = "sqlite-sqlx")]
+use sqlx::sqlite::{Sqlite, SqlitePool, SqliteRow};
+
 /// Trait to paginate results from a SQL query into a [`Page`] model from database using [`sqlx`].
-#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx"))]
+#[cfg(any(feature = "pg-sqlx", feature = "mysql-sqlx", feature = "sqlite-sqlx"))]
 pub trait SQLxPagination<DB, S>
 where
     DB: Database,
@@ -237,6 +240,48 @@ where
         let rows: Vec<PgRow> = query(
             QueryBuilder::<Postgres>::new(format!(
                 "WITH temp_table AS ({}) SELECT * from temp_table LIMIT {} OFFSET {};",
+                self.sql(),
+                size,
+                size * page,
+            ))
+            .sql(),
+        )
+        .fetch_all(pool)
+        .await?;
+
+        let items: Vec<S> = rows
+            .into_iter()
+            .map(|row| S::from_row(&row))
+            .collect::<Result<Vec<S>, _>>()?;
+
+        Ok(Page::new(&items, page, size, total as usize)?)
+    }
+}
+
+#[cfg(feature = "sqlite-sqlx")]
+impl<'q, S> SQLxPagination<Sqlite, S> for QueryBuilder<'q, Sqlite>
+where
+    S: for<'r> FromRow<'r, SqliteRow> + Clone,
+{
+    async fn paginate<'p>(
+        &self,
+        pool: &'p SqlitePool,
+        page: usize,
+        size: usize,
+    ) -> PaginationResult<Page<S>> {
+        let total: i64 = query_scalar(
+            QueryBuilder::<Sqlite>::new(format!(
+                "SELECT count(*) from ({}) as temp_table;",
+                self.sql()
+            ))
+            .sql(),
+        )
+        .fetch_one(pool)
+        .await?;
+
+        let rows: Vec<SqliteRow> = query(
+            QueryBuilder::<Sqlite>::new(format!(
+                "{} LIMIT {} OFFSET {};",
                 self.sql(),
                 size,
                 size * page,


### PR DESCRIPTION
This PR adds a new feature `sqlite-sqlx` to enable pagination with sqlite. 

Additionally, I took this as an opportunity to adjust the Cargo.toml. Previously if you enabled `pg-sqlx` feature it would enable the `postgres` **and** `mysql` features of `sqlx` adding unneeded bulk. With this adjustment only the requisite sqlx features are added.  