### PR TITLE
Remove use of $PWD from tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,7 @@ jobs:
         DB_HOST: ${{ secrets.DB_HOST }}
         PG_DB_PORT: ${{ secrets.PG_DB_PORT }}
         MYSQL_DB_PORT: ${{ secrets.MYSQL_DB_PORT }}
-        PWD: ${{ github.workspace }}
-        SQLITE_DB_PATH: ${{ secrets.SQLITE_DB_PATH }}
+        SQLITE_DB_PATH: ${{ github.workspace }}/${{ secrets.SQLITE_DB_PATH }}
       run: cargo llvm-cov --workspace --all-features --codecov --output-path codecov.json
 
     - name: Upload coverage to Codecov

--- a/page-hunter/tests/test_sqlx_pagination.rs
+++ b/page-hunter/tests/test_sqlx_pagination.rs
@@ -472,7 +472,7 @@ pub mod test_sqlite_pagination {
         use sqlx::sqlite::SqlitePoolOptions;
         use sqlx::{FromRow, QueryBuilder, Sqlite, SqlitePool};
 
-		let filepath: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
+        let filepath: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
 
         #[derive(Clone, FromRow)]
         #[allow(dead_code)]

--- a/page-hunter/tests/test_sqlx_pagination.rs
+++ b/page-hunter/tests/test_sqlx_pagination.rs
@@ -472,9 +472,7 @@ pub mod test_sqlite_pagination {
         use sqlx::sqlite::SqlitePoolOptions;
         use sqlx::{FromRow, QueryBuilder, Sqlite, SqlitePool};
 
-        let pwd: String = env::var("PWD").expect("PWD var not found");
-        let filename: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
-        let filepath: String = format!("{pwd}/{filename}");
+		let filepath: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
 
         #[derive(Clone, FromRow)]
         #[allow(dead_code)]
@@ -534,9 +532,7 @@ pub mod test_sqlite_pagination {
         use sqlx::sqlite::SqlitePoolOptions;
         use sqlx::{FromRow, QueryBuilder, Sqlite, SqlitePool};
 
-        let pwd: String = env::var("PWD").expect("PWD var not found");
-        let filename: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
-        let filepath: String = format!("{pwd}/{filename}");
+        let filepath: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
 
         #[derive(Clone, Debug, FromRow)]
         #[allow(dead_code)]
@@ -578,9 +574,7 @@ pub mod test_sqlite_pagination {
         use sqlx::sqlite::SqlitePoolOptions;
         use sqlx::{FromRow, QueryBuilder, Sqlite, SqlitePool};
 
-        let pwd: String = env::var("PWD").expect("PWD var not found");
-        let filename: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
-        let filepath: String = format!("{pwd}/{filename}");
+        let filepath: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
 
         #[derive(Clone, Debug, FromRow)]
         #[allow(dead_code)]
@@ -622,9 +616,7 @@ pub mod test_sqlite_pagination {
         use sqlx::sqlite::SqlitePoolOptions;
         use sqlx::{FromRow, QueryBuilder, Sqlite, SqlitePool};
 
-        let pwd: String = env::var("PWD").expect("PWD var not found");
-        let filename: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
-        let filepath: String = format!("{pwd}/{filename}");
+        let filepath: String = env::var("SQLITE_DB_PATH").expect("SQLITE_DB_PATH var not found");
 
         #[derive(Clone, Debug, FromRow)]
         #[allow(dead_code)]


### PR DESCRIPTION
This pull request focuses on simplifying the handling of the `SQLITE_DB_PATH` environment variable across the codebase. The main changes involve removing the use of the `PWD` environment variable and directly using `SQLITE_DB_PATH`.

Environment variable handling improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL104-R104): Updated the `SQLITE_DB_PATH` to use `${{ github.workspace }}/${{ secrets.SQLITE_DB_PATH }}` instead of just `${{ secrets.SQLITE_DB_PATH }}`.

Code simplification:

* [`page-hunter/tests/test_sqlx_pagination.rs`](diffhunk://#diff-edc2d1e55b15748de797bb7a0bb6490be3fdd69baf31d43b76baf3725a7140b7L475-R475): Removed the `PWD` environment variable and directly used `SQLITE_DB_PATH` in the `filepath` variable. [[1]](diffhunk://#diff-edc2d1e55b15748de797bb7a0bb6490be3fdd69baf31d43b76baf3725a7140b7L475-R475) [[2]](diffhunk://#diff-edc2d1e55b15748de797bb7a0bb6490be3fdd69baf31d43b76baf3725a7140b7L537-R535) [[3]](diffhunk://#diff-edc2d1e55b15748de797bb7a0bb6490be3fdd69baf31d43b76baf3725a7140b7L581-R577) [[4]](diffhunk://#diff-edc2d1e55b15748de797bb7a0bb6490be3fdd69baf31d43b76baf3725a7140b7L625-R619)