### PR TITLE
Restrict the utoipa version to be greater than or equal to 0.4.2 and less than 5.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,4 @@
 [workspace]
 resolver="2"
-members = [
-  "page-hunter",
-]
-
-default-members = [
-  "page-hunter",
-]
+members = ["page-hunter"]
+default-members = ["page-hunter"]

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 🚀 v0.3.1 [2025-01-05]
+
+### Fixed:
+
+- 🪚 Restrict ***utoipa*** version to greater than or equal to **0.4.2** and less than **0.5.0** by [@JMTamayo](https://github.com/JMTamayo).
+
+### Changed:
+
+- 🔨 Rename `ErrorKind::FieldValueError` to `ErrorKind::InvalidValue` **[⚠️ BREAKING CHANGE]** by [@JMTamayo](https://github.com/JMTamayo).
+
 ## 🚀 v0.3.0 [2024-10-13]
 
 ### Added:

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 
-- 🔨 Rename `ErrorKind::FieldValueError` to `ErrorKind::InvalidValue` **[⚠️ BREAKING CHANGE]** by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Improve Cargo.toml file format [@JMTamayo](https://github.com/JMTamayo).
 
 ## 🚀 v0.3.0 [2024-10-13]
 

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 
 [dependencies]
 serde = { version = ">=1.0.200", features = ["derive"],  optional = true }
-utoipa = { version = ">=4.2.0", optional = true}
+utoipa = { version = ">=4.2.0,<5.0.0", optional = true}
 sqlx = { version = ">=0.8.1", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This pull request includes several changes to the `page-hunter` project, focusing on dependency version restrictions, formatting improvements, and documentation updates.

Dependency version restrictions:

* [`page-hunter/Cargo.toml`](diffhunk://#diff-b66be18f3a8e4dacb33abd0fd4152b1ddd61f79ed96a368ac193112c1d525834L17-R17): Restricted the `utoipa` version to be greater than or equal to 0.4.2 and less than 5.0.0.

Formatting improvements:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R4): Simplified the `members` and `default-members` arrays by consolidating them into single-line formats.

Documentation updates:

* [`page-hunter/CHANGELOG.md`](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6R8-R17): Added a new entry for version 0.3.1, documenting the fixed `utoipa` version restriction and the improved `Cargo.toml` file format.