### PR TITLE
Update page-hunter version from v0.4.0 to v0.4.1

### DIFF
--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 🚀 v0.4.0 [Unreleased]
+## 🚀 v0.4.1 [2025-01-11]
+
+### Fixed:
+
+- 🪚 Fix README.md posting on crates.io [@JMTamayo](https://github.com/JMTamayo).
+
+## 🚀 v0.4.0 [2025-01-11]
 
 ### Added:
 

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "page-hunter"
 description = "The pagination powerhouse, built with Rust"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Juan Manuel Tamayo <jmtamayog23@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/jmtamayo/page-hunter"


### PR DESCRIPTION
This pull request includes a version update and a bug fix for the `page-hunter` project. The most important changes include updating the version number and fixing the README.md posting issue on crates.io.

Version update:

* [`page-hunter/Cargo.toml`](diffhunk://#diff-b66be18f3a8e4dacb33abd0fd4152b1ddd61f79ed96a368ac193112c1d525834L4-R4): Updated the version number from `0.4.0` to `0.4.1`.

Bug fix:

* [`page-hunter/CHANGELOG.md`](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6L8-R14): Added a new entry for version `0.4.1` with a fix for the README.md posting issue on crates.io.