### PR TITLE
Update page-hunter version from v0.4.1 to v0.4.2

### DIFF
--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "page-hunter"
 description = "The pagination powerhouse, built with Rust"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Juan Manuel Tamayo <jmtamayog23@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/jmtamayo/page-hunter"


### PR DESCRIPTION
This pull request includes a small change to the `page-hunter/Cargo.toml` file. The change updates the version of the package from `0.4.1` to `0.4.2`.