### PR TITLE
SQLxPagination requires a single connection instead of a complete pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Take a look at the [examples](https://github.com/JMTamayo/page-hunter/tree/main/
 To paginate records from a Postgres database:
 ```rust,no_run
   use page_hunter::{Page, SQLxPagination};
-  use sqlx::postgres::{PgPool, Postgres};
-  use sqlx::{FromRow, QueryBuilder};
+  use sqlx::postgres::{PgConnection, Postgres};
+  use sqlx::{Connection, FromRow, QueryBuilder};
   use uuid::Uuid;
 
   #[tokio::main]
@@ -213,7 +213,7 @@ To paginate records from a Postgres database:
       name: String,
     }
 
-    let pool: PgPool = PgPool::connect(
+    let mut conn: PgConnection = PgConnection::connect(
       "postgres://username:password@localhost/db"
     ).await.unwrap_or_else(|error| {
       panic!("Error connecting to database: {:?}", error);
@@ -224,13 +224,13 @@ To paginate records from a Postgres database:
     );
 
     let page: Page<Country> =
-      query.paginate(&pool, 0, 10).await.unwrap_or_else(|error| {
+      query.paginate(&mut conn, 0, 10).await.unwrap_or_else(|error| {
         panic!("Error paginating records: {:?}", error);
     });
   }
 ```
 
-Similar to using pagination for Postgres, `SQLxPagination` can be used for MySQL and SQLite.
+Similar to using pagination for Postgres, `SQLxPagination` can be used for MySQL and SQLite. If you are working with a connection pool, you can [Acquire](https://docs.rs/sqlx/latest/sqlx/trait.Acquire.html)  a single connection before running `paginate`.
 
 ## DEVELOPMENT
 To test `page-hunter`, follow these recommendations:

--- a/examples/axum/src/db/repository/categories.rs
+++ b/examples/axum/src/db/repository/categories.rs
@@ -73,8 +73,10 @@ impl<'p> CategoriesRepositoryMethods for CategoriesRepository<'p> {
             None => debug!("No name_like provided"),
         }
 
+        let mut conn = self.get_pool().acquire().await?;
+
         let categories: PaginatedCategories = query
-            .paginate(self.get_pool(), search_by.get_page(), search_by.get_size())
+            .paginate(&mut conn, search_by.get_page(), search_by.get_size())
             .await?;
 
         Ok(categories)

--- a/examples/axum/src/db/repository/products.rs
+++ b/examples/axum/src/db/repository/products.rs
@@ -124,8 +124,10 @@ impl<'p> ProductsRepositoryMethods for ProductsRepository<'p> {
             None => debug!("No category_name_like provided"),
         }
 
+        let mut conn = self.get_pool().acquire().await?;
+
         let products_base: PaginatedProductsBase = query
-            .paginate(self.get_pool(), search_by.get_page(), search_by.get_size())
+            .paginate(&mut conn, search_by.get_page(), search_by.get_size())
             .await?;
 
         let products: PaginatedProducts = Page::new(

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 🚀 v0.5.0 [Pending]
+
+### Changed:
+
+- 🔨 `SqlxPagination` requires a single connection and not a complete connection pool **[⚠️ BREAKING CHANGE]** by [@JMTamayo](https://github.com/JMTamayo).
+
 ## 🚀 v0.4.2 [2025-01-11]
 
 ### Changed:
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 
-- 🪚 Fix README.md posting on crates.io [@JMTamayo](https://github.com/JMTamayo).
+- 🪚 Fix README.md posting on crates.io by [@JMTamayo](https://github.com/JMTamayo).
 
 ## 🚀 v0.4.0 [2025-01-11]
 
@@ -26,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - 🔨 Include unit tests inside each module by [@JMTamayo](https://github.com/JMTamayo).
-- 🔨 Implement `SqlxPagination` in a more general way that applies to PostgreSQL, MySQL, and SQLite. Unify ***pg-sqlx***, ***mysql-sqlx*** and ***sqlite-sqlx*** features into ***sqlx*** feature by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Implement `SqlxPagination` in a more general way that applies to PostgreSQL, MySQL, and SQLite. Unify ***pg-sqlx***, ***mysql-sqlx*** and ***sqlite-sqlx*** features into ***sqlx*** feature **[⚠️ BREAKING CHANGE]** by [@JMTamayo](https://github.com/JMTamayo).
 - 🔨 Upgrade ***utoipa*** version to greater than or equal to **0.5.3** by [@JMTamayo](https://github.com/JMTamayo).
 - 🔨 Upgrade ***serde*** version to greater than or equal to **1.0.210** by [@JMTamayo](https://github.com/JMTamayo).
 - 🔨 Optimize the implementation of the `Debug`, `Clone`, `Serialize` and `ToSchema` traits by [@JMTamayo](https://github.com/JMTamayo).

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "page-hunter"
 description = "The pagination powerhouse, built with Rust"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Juan Manuel Tamayo <jmtamayog23@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/jmtamayo/page-hunter"

--- a/page-hunter/src/lib.rs
+++ b/page-hunter/src/lib.rs
@@ -181,8 +181,8 @@
 //! To paginate records from a Postgres database:
 //! ```rust,no_run
 //!   use page_hunter::{Page, SQLxPagination};
-//!   use sqlx::postgres::{PgPool, Postgres};
-//!   use sqlx::{FromRow, QueryBuilder};
+//!   use sqlx::postgres::{PgConnection, Postgres};
+//!   use sqlx::{Connection, FromRow, QueryBuilder};
 //!   use uuid::Uuid;
 //!
 //!   #[tokio::main]
@@ -193,7 +193,7 @@
 //!       name: String,
 //!     }
 //!
-//!     let pool: PgPool = PgPool::connect(
+//!     let mut conn: PgConnection = PgConnection::connect(
 //!       "postgres://username:password@localhost/db"
 //!     ).await.unwrap_or_else(|error| {
 //!       panic!("Error connecting to database: {:?}", error);
@@ -204,13 +204,13 @@
 //!     );
 //!
 //!     let page: Page<Country> =
-//!       query.paginate(&pool, 0, 10).await.unwrap_or_else(|error| {
+//!       query.paginate(&mut conn, 0, 10).await.unwrap_or_else(|error| {
 //!         panic!("Error paginating records: {:?}", error);
 //!     });
 //!   }
 //! ```
 //!
-//! Similar to using pagination for Postgres, [`SQLxPagination`] can be used for MySQL and SQLite.
+//! Similar to using pagination for Postgres, [`SQLxPagination`] can be used for MySQL and SQLite. If you are working with a connection pool, you can [Acquire](https://docs.rs/sqlx/latest/sqlx/trait.Acquire.html)  a single connection before running [paginate](`SQLxPagination::paginate`).
 mod book;
 mod errors;
 mod page;

--- a/page-hunter/src/pagination/sqlx/queries.rs
+++ b/page-hunter/src/pagination/sqlx/queries.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use sqlx::{
     query, query_scalar, Acquire, ColumnIndex, Database, Decode, Error as SqlxError, Executor,
     FromRow, IntoArguments, QueryBuilder, Type,
@@ -147,7 +149,7 @@ where
         conn: A,
         page: usize,
         size: usize,
-    ) -> impl std::future::Future<Output = PaginationResult<Page<S>>>;
+    ) -> impl Future<Output = PaginationResult<Page<S>>>;
 }
 
 impl<DB, A, S> SQLxPagination<DB, A, S> for QueryBuilder<'_, DB>
@@ -162,7 +164,6 @@ where
 {
     async fn paginate(&self, conn: A, page: usize, size: usize) -> PaginationResult<Page<S>> {
         let mut acquired_conn = conn.acquire().await?;
-
         paginate_rows(&mut acquired_conn, self, page, size).await
     }
 }

--- a/page-hunter/src/pagination/sqlx/queries.rs
+++ b/page-hunter/src/pagination/sqlx/queries.rs
@@ -83,7 +83,7 @@ where
 /// Paginate results from a SQL query into a [`Page`] model.
 ///
 /// ### Arguments:
-/// - **conn**: A mutable reference to a connection to the database, which must implement the [`Acquire`] trait.
+/// - **conn**: A mutable reference to a connection to the database.
 /// - ***query_str**: A reference to a SQL query string.
 /// - **page**: The page index.
 /// - **size**: The number of records per page.

--- a/page-hunter/src/pagination/sqlx/tests/test_pg.rs
+++ b/page-hunter/src/pagination/sqlx/tests/test_pg.rs
@@ -4,8 +4,8 @@ pub mod test_sqlx_pg_pagination {
     use std::env::var;
 
     use sqlx::{
-        postgres::{PgPool, PgPoolOptions, Postgres},
-        FromRow, QueryBuilder,
+        postgres::{PgConnection, PgPool, PgPoolOptions, Postgres},
+        Connection, FromRow, QueryBuilder,
     };
     use time::OffsetDateTime;
     use uuid::Uuid;
@@ -32,24 +32,21 @@ pub mod test_sqlx_pg_pagination {
             updated_at: Option<OffsetDateTime>,
         }
 
-        let pool: PgPool = match PgPoolOptions::new()
+        let pool: PgPool = PgPoolOptions::new()
             .max_connections(1)
             .connect(&format!(
                 "postgres://{}:{}@{}:{}/{}",
                 db_user, db_password, db_host, db_port, db_name
             ))
             .await
-        {
-            Ok(pool) => pool,
-            Err(e) => {
-                panic!("Failed to connect to Postgres: {:?}", e);
-            }
-        };
+            .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 2, 3).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 2, 3).await;
         assert!(users_pagination.is_ok());
 
         let users: Page<User> = users_pagination.unwrap();
@@ -99,24 +96,17 @@ pub mod test_sqlx_pg_pagination {
             updated_at: Option<OffsetDateTime>,
         }
 
-        let pool: PgPool = match PgPoolOptions::new()
-            .max_connections(1)
-            .connect(&format!(
-                "postgres://{}:{}@{}:{}/{}",
-                db_user, db_password, db_host, db_port, db_name
-            ))
-            .await
-        {
-            Ok(pool) => pool,
-            Err(e) => {
-                panic!("Failed to connect to Postgres: {:?}", e);
-            }
-        };
+        let mut conn: PgConnection = PgConnection::connect(&format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        ))
+        .await
+        .unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users;");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 2, 3).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 2, 3).await;
         assert!(users_pagination.is_err());
 
         let error: String = users_pagination.unwrap_err().to_string();
@@ -147,24 +137,21 @@ pub mod test_sqlx_pg_pagination {
             updated_at: Option<OffsetDateTime>,
         }
 
-        let pool: PgPool = match PgPoolOptions::new()
+        let pool: PgPool = PgPoolOptions::new()
             .max_connections(1)
             .connect(&format!(
                 "postgres://{}:{}@{}:{}/{}",
                 db_user, db_password, db_host, db_port, db_name
             ))
             .await
-        {
-            Ok(pool) => pool,
-            Err(e) => {
-                panic!("Failed to connect to Postgres: {:?}", e);
-            }
-        };
+            .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 2, 3).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 2, 3).await;
         assert!(users_pagination.is_err());
 
         let error: String = users_pagination.unwrap_err().to_string();
@@ -194,24 +181,21 @@ pub mod test_sqlx_pg_pagination {
             updated_at: Option<OffsetDateTime>,
         }
 
-        let pool: PgPool = match PgPoolOptions::new()
+        let pool: PgPool = PgPoolOptions::new()
             .max_connections(1)
             .connect(&format!(
                 "postgres://{}:{}@{}:{}/{}",
                 db_user, db_password, db_host, db_port, db_name
             ))
             .await
-        {
-            Ok(pool) => pool,
-            Err(e) => {
-                panic!("Failed to connect to Postgres: {:?}", e);
-            }
-        };
+            .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 5, 30).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 5, 30).await;
         assert!(users_pagination.is_err());
 
         let error: String = users_pagination.unwrap_err().to_string();


### PR DESCRIPTION
This pull request includes significant changes to the `page-hunter` project, primarily focusing on modifying the `SQLxPagination` to require a single connection instead of a connection pool. This update affects multiple files and introduces breaking changes. Additionally, the version has been updated to `0.5.0`.

### Breaking Changes:

* `README.md`, `page-hunter/src/lib.rs`: Updated examples to use `PgConnection` instead of `PgPool`, and added instructions for acquiring a single connection from a pool before running `paginate`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204-R205) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L216-R216) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L227-R233) [[4]](diffhunk://#diff-98b36862e570e602d4e1243b2002ed62181ef1e476b652e63f282f1a700f59a9L184-R185) [[5]](diffhunk://#diff-98b36862e570e602d4e1243b2002ed62181ef1e476b652e63f282f1a700f59a9L196-R196) [[6]](diffhunk://#diff-98b36862e570e602d4e1243b2002ed62181ef1e476b652e63f282f1a700f59a9L207-R213)
* [`page-hunter/CHANGELOG.md`](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6R8-R13): Documented the breaking change that `SqlxPagination` now requires a single connection instead of a connection pool. [[1]](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6R8-R13) [[2]](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6L18-R24) [[3]](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6L29-R35)
* [`page-hunter/Cargo.toml`](diffhunk://#diff-b66be18f3a8e4dacb33abd0fd4152b1ddd61f79ed96a368ac193112c1d525834L4-R4): Updated the version to `0.5.0`.

### Codebase Updates:

* `examples/axum/src/db/repository/categories.rs`, `examples/axum/src/db/repository/products.rs`: Modified to acquire a single connection from the pool before running `paginate`. [[1]](diffhunk://#diff-224cd2775e8c94344ba22aa730ebb2a0b407a1382252965f7b9eb338346b9962R76-R79) [[2]](diffhunk://#diff-1b85346dad9f26c7812d76958fd4f36cfd9681c950b2c26eab2ba579269b56c6R127-R130)
* [`page-hunter/src/pagination/sqlx/queries.rs`](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cR1-R5): Refactored `get_total_rows`, `get_page_rows`, and `paginate_rows` functions to use a SQL query string instead of `QueryBuilder`. Updated `SQLxPagination` trait and its implementation accordingly. [[1]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cR1-R5) [[2]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL13-R21) [[3]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL28-R30) [[4]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL42-R49) [[5]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL59-R58) [[6]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL93-R108) [[7]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL126-L129) [[8]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL140-R130) [[9]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL150-R162)
* [`page-hunter/src/pagination/sqlx/tests/test_pg.rs`](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL7-R8): Updated tests to use `PgConnection` and acquire a single connection from the pool before running `paginate`. [[1]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL7-R8) [[2]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL35-R49) [[3]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL102-R109) [[4]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL150-R154)