### PR TITLE
Simplify SQLxPagination Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ To paginate records from a Postgres database:
   async fn main() {
     #[derive(Clone, Debug, FromRow)]
     pub struct Country {
-      id: i8,
+      id: i32,
       name: String,
     }
 

--- a/README.md
+++ b/README.md
@@ -203,13 +203,12 @@ To paginate records from a Postgres database:
   use page_hunter::{Page, SQLxPagination};
   use sqlx::postgres::{PgConnection, Postgres};
   use sqlx::{Connection, FromRow, QueryBuilder};
-  use uuid::Uuid;
 
   #[tokio::main]
   async fn main() {
     #[derive(Clone, Debug, FromRow)]
     pub struct Country {
-      id: Uuid,
+      id: i8,
       name: String,
     }
 

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🔨 Remove Makefile from project by [@JMTamayo](https://github.com/JMTamayo).
 - 🔨 Simplify `SqlxPagination` implementation to reduce the number of lines of code by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Remove the use of uuid and time from tests by [@JMTamayo](https://github.com/JMTamayo).
 
 ### Docs:
 

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - 🔨 Remove Makefile from project by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Simplify `SqlxPagination` implementation to reduce the number of lines of code by [@JMTamayo](https://github.com/JMTamayo).
 
 ### Docs:
 

--- a/page-hunter/CHANGELOG.md
+++ b/page-hunter/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 📝 Remove makefile commands from README.md by [@JMTamayo](https://github.com/JMTamayo).
 
-## 🚀 v0.5.0 [Pending]
+## 🚀 v0.5.0 [2025-01-15]
 
 ### Changed:
 

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -19,10 +19,8 @@ sqlx = { version = ">=0.8.1", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
 tokio ={ version = "1.43.0", features = ["full"] }
-sqlx = { version = "0.8.3", features = ["uuid", "time", "postgres"] }
+sqlx = { version = "0.8.3", features = ["postgres"] }
 serde_json = { version = "1.0.134" }
-uuid = { version = "1.11.0" }
-time = { version = "0.3.37" }
 
 [features]
 serde = ["dep:serde"]

--- a/page-hunter/src/lib.rs
+++ b/page-hunter/src/lib.rs
@@ -188,7 +188,7 @@
 //!   async fn main() {
 //!     #[derive(Clone, Debug, FromRow)]
 //!     pub struct Country {
-//!       id: i8,
+//!       id: i32,
 //!       name: String,
 //!     }
 //!

--- a/page-hunter/src/lib.rs
+++ b/page-hunter/src/lib.rs
@@ -183,13 +183,12 @@
 //!   use page_hunter::{Page, SQLxPagination};
 //!   use sqlx::postgres::{PgConnection, Postgres};
 //!   use sqlx::{Connection, FromRow, QueryBuilder};
-//!   use uuid::Uuid;
 //!
 //!   #[tokio::main]
 //!   async fn main() {
 //!     #[derive(Clone, Debug, FromRow)]
 //!     pub struct Country {
-//!       id: Uuid,
+//!       id: i8,
 //!       name: String,
 //!     }
 //!

--- a/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000107_create_schema.down.sql
+++ b/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000107_create_schema.down.sql
@@ -1,2 +1,2 @@
 -- Add down migration script here
-DROP EXTENSION "uuid-ossp";
+DROP SCHEMA IF EXISTS test_page_hunter;

--- a/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000107_create_schema.up.sql
+++ b/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000107_create_schema.up.sql
@@ -1,4 +1,2 @@
 -- Add up migration script here
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
 CREATE SCHEMA IF NOT EXISTS test_page_hunter;

--- a/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000349_create_table_users.up.sql
+++ b/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000349_create_table_users.up.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS test_page_hunter.users (
   id SERIAL PRIMARY KEY NOT NULL,
   username VARCHAR(255) NOT NULL,
   hashed_password VARCHAR(255) NOT NULL,
-  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON test_page_hunter.users(username);

--- a/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000349_create_table_users.up.sql
+++ b/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000349_create_table_users.up.sql
@@ -1,11 +1,9 @@
 -- Add up migration script here
 CREATE TABLE IF NOT EXISTS test_page_hunter.users (
-  id UUID default uuid_generate_v1() PRIMARY KEY NOT NULL,
+  id SERIAL PRIMARY KEY NOT NULL,
   username VARCHAR(255) NOT NULL,
   hashed_password VARCHAR(255) NOT NULL,
   is_active BOOLEAN NOT NULL DEFAULT TRUE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMPTZ
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON test_page_hunter.users(username);

--- a/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523002231_populate_users.up.sql
+++ b/page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523002231_populate_users.up.sql
@@ -1,11 +1,11 @@
 -- Add up migration script here
 DO $$
 DECLARE
-    user_id UUID;
+    user_id INTEGER;
 BEGIN
     FOR i IN 1..100 LOOP
-        INSERT INTO test_page_hunter.users (username, hashed_password, is_active, created_at)
-        VALUES ('user' || i, 'hashed_password' || i, TRUE, NOW())
+        INSERT INTO test_page_hunter.users (id, username, hashed_password, is_active)
+        VALUES (i, 'user' || i, 'hashed_password' || i, TRUE)
         RETURNING id INTO user_id;
     END LOOP;
 END $$;

--- a/page-hunter/src/pagination/sqlx/tests/test_pg.rs
+++ b/page-hunter/src/pagination/sqlx/tests/test_pg.rs
@@ -4,11 +4,10 @@ pub mod test_sqlx_pg_pagination {
     use std::env::var;
 
     use sqlx::{
+        pool::PoolConnection,
         postgres::{PgConnection, PgPool, PgPoolOptions, Postgres},
         Connection, FromRow, QueryBuilder,
     };
-    use time::OffsetDateTime;
-    use uuid::Uuid;
 
     use crate::*;
 
@@ -24,12 +23,10 @@ pub mod test_sqlx_pg_pagination {
         #[derive(Clone, FromRow)]
         #[allow(dead_code)]
         pub struct User {
-            id: Uuid,
+            id: i32,
             username: String,
             hashed_password: String,
             is_active: bool,
-            created_at: OffsetDateTime,
-            updated_at: Option<OffsetDateTime>,
         }
 
         let pool: PgPool = PgPoolOptions::new()
@@ -41,7 +38,7 @@ pub mod test_sqlx_pg_pagination {
             .await
             .unwrap();
 
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn: PoolConnection<Postgres> = pool.acquire().await.unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
@@ -59,6 +56,10 @@ pub mod test_sqlx_pg_pagination {
         assert_eq!(users.get_previous_page(), Some(1));
         assert_eq!(users.get_next_page(), Some(3));
 
+        assert_eq!(users.get_items()[0].id, 7);
+        assert_eq!(users.get_items()[1].id, 8);
+        assert_eq!(users.get_items()[2].id, 9);
+
         assert_eq!(users.get_items()[0].username, "user7");
         assert_eq!(users.get_items()[1].username, "user8");
         assert_eq!(users.get_items()[2].username, "user9");
@@ -70,10 +71,6 @@ pub mod test_sqlx_pg_pagination {
         assert_eq!(users.get_items()[0].is_active, true);
         assert_eq!(users.get_items()[1].is_active, true);
         assert_eq!(users.get_items()[2].is_active, true);
-
-        assert!(users.get_items()[0].updated_at.is_none());
-        assert!(users.get_items()[1].updated_at.is_none());
-        assert!(users.get_items()[2].updated_at.is_none());
     }
 
     /// Test database error when is not possible to get total by invalid query
@@ -88,12 +85,10 @@ pub mod test_sqlx_pg_pagination {
         #[derive(Clone, Debug, FromRow)]
         #[allow(dead_code)]
         pub struct User {
-            id: Uuid,
+            id: i32,
             username: String,
             hashed_password: String,
             is_active: bool,
-            created_at: OffsetDateTime,
-            updated_at: Option<OffsetDateTime>,
         }
 
         let mut conn: PgConnection = PgConnection::connect(&format!(
@@ -128,13 +123,11 @@ pub mod test_sqlx_pg_pagination {
         #[derive(Clone, Debug, FromRow)]
         #[allow(dead_code)]
         pub struct User {
-            id: Uuid,
+            id: i32,
             username: String,
             hashed_password: String,
             age: i32,
             is_active: bool,
-            created_at: OffsetDateTime,
-            updated_at: Option<OffsetDateTime>,
         }
 
         let pool: PgPool = PgPoolOptions::new()
@@ -146,7 +139,7 @@ pub mod test_sqlx_pg_pagination {
             .await
             .unwrap();
 
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn: PoolConnection<Postgres> = pool.acquire().await.unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
@@ -173,12 +166,10 @@ pub mod test_sqlx_pg_pagination {
         #[derive(Clone, Debug, FromRow)]
         #[allow(dead_code)]
         pub struct User {
-            id: Uuid,
+            id: i32,
             username: String,
             hashed_password: String,
             is_active: bool,
-            created_at: OffsetDateTime,
-            updated_at: Option<OffsetDateTime>,
         }
 
         let pool: PgPool = PgPoolOptions::new()
@@ -190,7 +181,7 @@ pub mod test_sqlx_pg_pagination {
             .await
             .unwrap();
 
-        let mut conn = pool.acquire().await.unwrap();
+        let mut conn: PoolConnection<Postgres> = pool.acquire().await.unwrap();
 
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");


### PR DESCRIPTION
This pull request includes several changes to the `page-hunter` project, mainly focusing on simplifying the codebase, removing unnecessary dependencies, and updating the database schema and tests. The most important changes include removing the use of `uuid` and `time` crates, simplifying the `SqlxPagination` implementation, and updating the database schema and tests to reflect these changes.

### Codebase simplification:
* Removed the use of `uuid` and `time` crates from the project and tests. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R211) `Cargo.toml` [[2]](diffhunk://#diff-b66be18f3a8e4dacb33abd0fd4152b1ddd61f79ed96a368ac193112c1d525834L22-L25) `page-hunter/src/lib.rs` [[3]](diffhunk://#diff-98b36862e570e602d4e1243b2002ed62181ef1e476b652e63f282f1a700f59a9L186-R191) `page-hunter/src/pagination/sqlx/tests/test_pg.rs` [[4]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dR7-L11) [[5]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL27-L32) [[6]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL91-L96) [[7]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL131-L137) [[8]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL149-R142) [[9]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL176-L181) [[10]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL193-R184)
* Simplified the `SqlxPagination` implementation to reduce the number of lines of code. (`page-hunter/src/pagination/sqlx/queries.rs` [[1]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL11-L115) [[2]](diffhunk://#diff-cc5ef0715780e23c1d25b1c22fe34ab45f9d7b746fa36bbad1f0866632d75d1cL149-R78)

### Database schema updates:
* Updated the database schema to remove the use of `uuid` and `time` fields and use `SERIAL` for primary keys. (`page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000107_create_schema.down.sql` [[1]](diffhunk://#diff-43a18504f1889fa3965cc89d30c95226db0517e28b211912964105df81ffdffaL2-R2) `page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000107_create_schema.up.sql` [[2]](diffhunk://#diff-3274080f105a974919be0b433d3fdc1fb2ffc69f958ff0bdfa29055ec4cb1c4eL2-L3) `page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523000349_create_table_users.up.sql` [[3]](diffhunk://#diff-97c2fb5ef1202d16b68010a9ab8efe6563b8e43eb2c61fa644cb66bae60bec6bL3-R6) `page-hunter/src/pagination/sqlx/tests/pg/migrations/20240523002231_populate_users.up.sql` [[4]](diffhunk://#diff-672a8067c59d84810f2e2ad545770fd983d922346038a17a5afb4931cb5c1328L4-R8)

### Test updates:
* Updated tests to reflect the removal of `uuid` and `time` fields and to use `i32` for primary keys. (`page-hunter/src/pagination/sqlx/tests/test_pg.rs` [[1]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dR59-R62) [[2]](diffhunk://#diff-e7fff6a6fe680c789203aa0bea2dd87ddffda8bc9c8d2773885438b16ba4190dL73-L76)

### Documentation updates:
* Updated the `CHANGELOG.md` to reflect the changes made in this pull request. (`page-hunter/CHANGELOG.md` [page-hunter/CHANGELOG.mdR13-R20](diffhunk://#diff-796b552e2e17042f9cdc871a10c457777b7e0cdcf342074efc6c4fd37bac24b6R13-R20))