### PR TITLE
Release v0.7.0 improvements: SQLx pagination, docs, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,20 @@ on:
     - cron: "0 5 * * 0"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   Format:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: "Repository: Fetch"
@@ -27,20 +35,29 @@ jobs:
         with:
           components: rustfmt
 
+      - name: "Setup: Cargo Cache"
+        uses: Swatinem/rust-cache@v2
+
       - name: "Step: Check Format"
-        run: cargo fmt --package page-hunter --all --check
+        run: cargo fmt --package page-hunter --all --check --verbose
 
   Lints:
     runs-on: ubuntu-24.04
-    needs: Format
+    timeout-minutes: 20
     strategy:
-      matrix:
-        feature:
-          - no-features
-          - all-features
-          - serde
-          - utoipa
-          - sqlx
+      fail-fast: false
+      matrix: &feature_matrix
+        include:
+          - feature: no-features
+            cargo_flags: ""
+          - feature: all-features
+            cargo_flags: "--all-features"
+          - feature: serde
+            cargo_flags: "--features serde"
+          - feature: utoipa
+            cargo_flags: "--features utoipa"
+          - feature: sqlx
+            cargo_flags: "--features sqlx"
 
     steps:
       - name: "Repository: Fetch"
@@ -51,27 +68,18 @@ jobs:
         with:
           components: clippy
 
+      - name: "Setup: Cargo Cache"
+        uses: Swatinem/rust-cache@v2
+
       - name: "Step: Lints"
-        run: |
-          if [[ ${{ matrix.feature }} == all-features ]]; then
-            cargo clippy --package page-hunter --all-features
-          elif [[ ${{ matrix.feature }} == no-features ]]; then
-            cargo clippy --package page-hunter
-          else
-            cargo clippy --package page-hunter --features ${{ matrix.feature }}
-          fi
+        run: cargo clippy --package page-hunter ${{ matrix.cargo_flags }} --locked -- -D warnings
 
   Build:
     runs-on: ubuntu-24.04
-    needs: Lints
+    timeout-minutes: 20
     strategy:
-      matrix:
-        feature:
-          - no-features
-          - all-features
-          - serde
-          - utoipa
-          - sqlx
+      fail-fast: false
+      matrix: *feature_matrix
 
     steps:
       - name: "Repository: Fetch"
@@ -80,19 +88,15 @@ jobs:
       - name: "Setup: Install Rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: "Setup: Cargo Cache"
+        uses: Swatinem/rust-cache@v2
+
       - name: "Step: Build"
-        run: |
-          if [[ ${{ matrix.feature }} == all-features ]]; then
-            cargo build --package page-hunter --all-features
-          elif [[ ${{ matrix.feature }} == no-features ]]; then
-            cargo build --package page-hunter
-          else
-            cargo build --package page-hunter --features ${{ matrix.feature }}
-          fi
+        run: cargo check --package page-hunter ${{ matrix.cargo_flags }} --locked --verbose
 
   Docs:
     runs-on: ubuntu-24.04
-    needs: Build
+    timeout-minutes: 20
 
     steps:
       - name: "Repository: Fetch"
@@ -101,22 +105,30 @@ jobs:
       - name: "Setup: Install Rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: "Setup: Cargo Cache"
+        uses: Swatinem/rust-cache@v2
+
       - name: "Step: Build Doc"
-        run: cargo doc --package page-hunter --all-features --document-private-items --verbose
+        run: cargo doc --package page-hunter --all-features --document-private-items --locked --verbose
 
   Tests:
     runs-on: ubuntu-24.04
-    needs: Docs
+    timeout-minutes: 30
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:16
         env:
-          POSTGRES_USER: ${{ secrets.DB_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          POSTGRES_DB: ${{ secrets.DB_NAME }}
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: docker
+          POSTGRES_DB: test
         ports:
           - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test -d test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: "Repository: Fetch"
@@ -125,7 +137,10 @@ jobs:
       - name: "Setup: Install Rust"
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov,cargo-nextest
+          tool: cargo-llvm-cov
+
+      - name: "Setup: Cargo Cache"
+        uses: Swatinem/rust-cache@v2
 
       - name: "Setup: Install SQLx Cli"
         run: cargo install sqlx-cli --no-default-features --features postgres
@@ -133,20 +148,20 @@ jobs:
       - name: "Setup: Postgres Database Migrations"
         env:
           MIGRATIONS_PATH: page-hunter/src/pagination/sqlx/tests/pg/migrations
-          DATABASE_URL: postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASSWORD }}@${{ secrets.DB_HOST }}:${{ secrets.PG_DB_PORT }}/${{ secrets.DB_NAME }}
+          DATABASE_URL: postgres://test:docker@127.0.0.1:5432/test
         run: sqlx migrate run --source ${{ env.MIGRATIONS_PATH }}
 
       - name: "Step: Doc Tests"
-        run: cargo test --package page-hunter --all-features --doc
+        run: cargo test --package page-hunter --all-features --doc --locked
 
       - name: "Step: Unit & Integration Tests"
         env:
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          DB_HOST: ${{ secrets.DB_HOST }}
-          PG_DB_PORT: ${{ secrets.PG_DB_PORT }}
-        run: cargo llvm-cov --package page-hunter --all-features --codecov --output-path codecov.json
+          DB_USER: test
+          DB_PASSWORD: docker
+          DB_NAME: test
+          DB_HOST: 127.0.0.1
+          PG_DB_PORT: 5432
+        run: cargo llvm-cov --package page-hunter --all-features --locked --codecov --output-path codecov.json
 
       - name: "Step: Publish Results"
         uses: codecov/codecov-action@v4
@@ -158,7 +173,7 @@ jobs:
 
   Security:
     runs-on: ubuntu-24.04
-    needs: Tests
+    timeout-minutes: 15
 
     steps:
       - name: "Repository: Fetch"

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ venv/
 
 # SQLite test database file:
 test.db
+
+# Local scripts
+scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ test.db
 
 # Local scripts
 scripts/
+
+# Code coverage
+codecov.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 🚀 0.7.0 [2026-03-07]
+
+### Added:
+
+- 🧑🏻‍💻 Add `page_hunter::prelude` module to simplify common imports (`Page`, `Book`, pagination helpers, errors and `SQLxPagination` when `sqlx` feature is enabled).
+
+### Changed:
+
+- 🔨 Update `SQLxPagination::paginate` to accept a generic source implementing `Acquire`, allowing `&Pool<DB>` and `&mut DB::Connection` on the same API **[⚠️ BREAKING CHANGE]**.
+- 🔨 Update SQLx pagination internals to start transactions from the generic `Acquire` source.
+- 🔨 Update `axum` example repositories to paginate directly from `PgPool`.
+- 🔨 Restrict dependency definitions in `page-hunter/Cargo.toml` by replacing open-ended `>=` constraints with explicit versions and explicit SQLx feature flags.
+- 🔨 Strengthen CI workflow with safer defaults and better reliability: minimal permissions, run concurrency control, Cargo cache, fixed Postgres image/version, DB healthcheck, explicit `--locked` usage, and strict clippy (`-D warnings`).
+- 🔨 Simplify CI feature matrix maintenance by reusing a single matrix definition for both lint and build jobs.
+
+### Docs:
+
+- 📝 Rewrite `README.md` with a quicker onboarding flow, clearer examples, and more discoverable developer commands.
+- 📝 Improve crate-level docs in `lib.rs` to provide a cleaner docs.rs experience and updated SQLx usage (`Pool` or `Connection`).
+- 📝 Note: local helper scripts are not part of the published package/changelog artifacts when ignored by repository rules.
+
 ## 🚀 0.6.0 [2025-12-20]
 
 ### Changed:
@@ -154,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed:
 
-- ❌ Remove **From**<**sqlx::Error**> for `PaginationError` by [@JMTamayo](https://github.com/JMTamayo).
+- ❌ Remove `From<sqlx::Error>` for `PaginationError` by [@JMTamayo](https://github.com/JMTamayo).
 
 ### Docs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- 🧑🏻‍💻 Add `page_hunter::prelude` module to simplify common imports (`Page`, `Book`, pagination helpers, errors and `SQLxPagination` when `sqlx` feature is enabled).
+- 🧑🏻‍💻 Add `page_hunter::prelude` module to simplify common imports (`Page`, `Book`, pagination helpers, errors and `SQLxPagination` when `sqlx` feature is enabled) by [@JMTamayo](https://github.com/JMTamayo).
 
 ### Changed:
 
-- 🔨 Update `SQLxPagination::paginate` to accept a generic source implementing `Acquire`, allowing `&Pool<DB>` and `&mut DB::Connection` on the same API **[⚠️ BREAKING CHANGE]**.
-- 🔨 Update SQLx pagination internals to start transactions from the generic `Acquire` source.
-- 🔨 Update `axum` example repositories to paginate directly from `PgPool`.
-- 🔨 Restrict dependency definitions in `page-hunter/Cargo.toml` by replacing open-ended `>=` constraints with explicit versions and explicit SQLx feature flags.
-- 🔨 Refresh crate development dependencies in `page-hunter/Cargo.toml` (`tokio`, `serde_json`) and update example dependencies in `examples/axum/Cargo.toml` and `examples/actix-web/Cargo.toml`.
-- 🔨 Strengthen CI workflow with safer defaults and better reliability: minimal permissions, run concurrency control, Cargo cache, fixed Postgres image/version, DB healthcheck, explicit `--locked` usage, and strict clippy (`-D warnings`).
-- 🔨 Simplify CI feature matrix maintenance by reusing a single matrix definition for both lint and build jobs.
+- 🔨 Update `SQLxPagination::paginate` to accept a generic source implementing `Acquire`, allowing `&Pool<DB>` and `&mut DB::Connection` on the same API **[⚠️ BREAKING CHANGE]** by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Update SQLx pagination internals to start transactions from the generic `Acquire` source by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Update `axum` example repositories to paginate directly from `PgPool` by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Restrict dependency definitions in `page-hunter/Cargo.toml` by replacing open-ended `>=` constraints with explicit versions and explicit SQLx feature flags by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Refresh crate development dependencies in `page-hunter/Cargo.toml` (`tokio`, `serde_json`) and update example dependencies in `examples/axum/Cargo.toml` and `examples/actix-web/Cargo.toml` by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Strengthen CI workflow with safer defaults and better reliability: minimal permissions, run concurrency control, Cargo cache, fixed Postgres image/version, DB healthcheck, explicit `--locked` usage, and strict clippy (`-D warnings`) by [@JMTamayo](https://github.com/JMTamayo).
+- 🔨 Simplify CI feature matrix maintenance by reusing a single matrix definition for both lint and build jobs by [@JMTamayo](https://github.com/JMTamayo).
 
 ### Docs:
 
-- 📝 Rewrite `README.md` with a quicker onboarding flow, clearer examples, and more discoverable developer commands.
-- 📝 Improve crate-level docs in `lib.rs` to provide a cleaner docs.rs experience and updated SQLx usage (`Pool` or `Connection`).
-- 📝 Improve `examples/README.md`, `examples/actix-web/README.md`, and `examples/axum/README.md` with clearer prerequisites, local run steps, and quick API endpoints.
-- 📝 Note: local helper scripts are not part of the published package/changelog artifacts when ignored by repository rules.
+- 📝 Rewrite `README.md` with a quicker onboarding flow, clearer examples, and more discoverable developer commands by [@JMTamayo](https://github.com/JMTamayo).
+- 📝 Improve crate-level docs in `lib.rs` to provide a cleaner docs.rs experience and updated SQLx usage (`Pool` or `Connection`) by [@JMTamayo](https://github.com/JMTamayo).
+- 📝 Improve `examples/README.md`, `examples/actix-web/README.md`, and `examples/axum/README.md` with clearer prerequisites, local run steps, and quick API endpoints by [@JMTamayo](https://github.com/JMTamayo).
+- 📝 Note: local helper scripts are not part of the published package/changelog artifacts when ignored by repository rules by [@JMTamayo](https://github.com/JMTamayo).
 
 ### Removed:
 
-- ❌ Ignore generated local coverage artifact `codecov.json` via `.gitignore`.
+- ❌ Ignore generated local coverage artifact `codecov.json` via `.gitignore` by [@JMTamayo](https://github.com/JMTamayo).
 
 ## 🚀 0.6.0 [2025-12-20]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔨 Update SQLx pagination internals to start transactions from the generic `Acquire` source.
 - 🔨 Update `axum` example repositories to paginate directly from `PgPool`.
 - 🔨 Restrict dependency definitions in `page-hunter/Cargo.toml` by replacing open-ended `>=` constraints with explicit versions and explicit SQLx feature flags.
+- 🔨 Refresh crate development dependencies in `page-hunter/Cargo.toml` (`tokio`, `serde_json`) and update example dependencies in `examples/axum/Cargo.toml` and `examples/actix-web/Cargo.toml`.
 - 🔨 Strengthen CI workflow with safer defaults and better reliability: minimal permissions, run concurrency control, Cargo cache, fixed Postgres image/version, DB healthcheck, explicit `--locked` usage, and strict clippy (`-D warnings`).
 - 🔨 Simplify CI feature matrix maintenance by reusing a single matrix definition for both lint and build jobs.
 
@@ -24,7 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 📝 Rewrite `README.md` with a quicker onboarding flow, clearer examples, and more discoverable developer commands.
 - 📝 Improve crate-level docs in `lib.rs` to provide a cleaner docs.rs experience and updated SQLx usage (`Pool` or `Connection`).
+- 📝 Improve `examples/README.md`, `examples/actix-web/README.md`, and `examples/axum/README.md` with clearer prerequisites, local run steps, and quick API endpoints.
 - 📝 Note: local helper scripts are not part of the published package/changelog artifacts when ignored by repository rules.
+
+### Removed:
+
+- ❌ Ignore generated local coverage artifact `codecov.json` via `.gitignore`.
 
 ## 🚀 0.6.0 [2025-12-20]
 

--- a/README.md
+++ b/README.md
@@ -1,377 +1,300 @@
 # Page Hunter
 
 <div align="left">
-	<img src="https://img.shields.io/github/license/JMTamayo/page-hunter">
-	<a href="https://deps.rs/repo/github/JMTamayo/page-hunter">
-		<img src="https://deps.rs/repo/github/JMTamayo/page-hunter/status.svg">
-	</a>
-	<a href="https://github.com/JMTamayo/page-hunter/actions/workflows/ci.yml">
-		<img src="https://github.com/JMTamayo/page-hunter/actions/workflows/ci.yml/badge.svg">
-	</a>
-	<a href="https://codecov.io/gh/JMTamayo/page-hunter">
-		<img src="https://codecov.io/gh/JMTamayo/page-hunter/graph/badge.svg?token=R1LAPNSV5J">
-	</a>
-	<a href="https://crates.io/crates/page-hunter">
-		<img src="https://img.shields.io/crates/v/page-hunter.svg?label=crates.io&color=orange&logo=rust">
-	</a>
-	<a href="http://docs.rs/page-hunter/latest/">
-		<img src="https://img.shields.io/static/v1?label=docs.rs&message=latest&color=blue&logo=docsdotrs">
-	</a>
+  <img src="https://img.shields.io/github/license/JMTamayo/page-hunter">
+  <a href="https://deps.rs/repo/github/JMTamayo/page-hunter">
+    <img src="https://deps.rs/repo/github/JMTamayo/page-hunter/status.svg">
+  </a>
+  <a href="https://github.com/JMTamayo/page-hunter/actions/workflows/ci.yml">
+    <img src="https://github.com/JMTamayo/page-hunter/actions/workflows/ci.yml/badge.svg">
+  </a>
+  <a href="https://codecov.io/gh/JMTamayo/page-hunter">
+    <img src="https://codecov.io/gh/JMTamayo/page-hunter/graph/badge.svg?token=R1LAPNSV5J">
+  </a>
+  <a href="https://crates.io/crates/page-hunter">
+    <img src="https://img.shields.io/crates/v/page-hunter.svg?label=crates.io&color=orange&logo=rust">
+  </a>
+  <a href="https://docs.rs/page-hunter/latest/">
+    <img src="https://img.shields.io/static/v1?label=docs.rs&message=latest&color=blue&logo=docsdotrs">
+  </a>
 </div>
 
-***Page Hunter*** library is a Rust-based pagination tool that provides a way to manage and navigate through pages of data.
-It offers a set of resources that encapsulates all the necessary pagination information such as the current page, total pages, previous page, next page and the items on the current page.
+Strong, reusable pagination models for Rust APIs and services.
 
-The library also includes validation methods to ensure the integrity of the pagination data.
-It's designed to be flexible and easy to integrate into any Rust project that requires pagination functionality and standard data validation.
+`page-hunter` gives you:
 
-## CRATE FEATURES
-- `serde`: Add [Serialize](https://docs.rs/serde/1.0.200/serde/trait.Serialize.html) and [Deserialize](https://docs.rs/serde/1.0.200/serde/trait.Deserialize.html) support for `Page` and `Book` based on [serde](https://crates.io/crates/serde/1.0.200). This feature is useful for implementing pagination models as a request or response body in REST APIs, among other implementations.
-- `utoipa`: Add [ToSchema](https://docs.rs/utoipa/4.2.0/utoipa/trait.ToSchema.html) support for `Page` and  `Book` based on [utoipa](https://crates.io/crates/utoipa/4.2.0). This feature is useful for generating OpenAPI schemas for pagination models. This feature depends on the `serde` feature and therefore you only need to implement `utoipa` to get both.
-- `sqlx`: Add support for pagination with [SQLx](https://docs.rs/sqlx/0.8.1/sqlx/) for Postgres, MySQL and SQLite databases.
+- A validated `Page<T>` model for one page of records.
+- A `Book<T>` model for full paging snapshots.
+- Helpers for in-memory collections and SQLx queries.
+- Optional `serde` and `utoipa` support for API contracts.
 
-## BASIC OPERATION
-The **page-hunter** library provides two main models to manage pagination:
-- `Page`: Represents a page of records with the current page, total pages, previous page, next page, and the items on the current page.
-- `Book`: Represents a book of pages with a collection of `Page` instances.
+## Why Page Hunter?
 
-The library also provides a set of functions to paginate records into a `Page` model and bind records into a `Book` model. The following examples show how to use the **page-hunter** library:
+Most projects eventually build pagination by hand, then repeat the same logic in multiple services.
+`page-hunter` turns that into a single, tested abstraction.
 
-### Paginate records:
-If you need to paginate records and get a specific `Page`:
-```rust,no_run
-  use page_hunter::{Page, paginate_records, RecordsPagination};
+- Consistent metadata (`page`, `size`, `total`, `pages`, `previous_page`, `next_page`).
+- Validation rules enforced by construction.
+- One API that works with records in memory and SQLx queries.
 
-  let records: Vec<u32> = vec![1, 2, 3, 4, 5];
-  let page: usize = 0;
-  let size: usize = 2;
+## Quick Start
 
-  // Using the paginate_records function:
-  let page_model: Page<u32> = match paginate_records(&records, page, size) {
-    Ok(p) => p,
-    Err(e) => panic!("Error paginating records: {:?}", e),
-  };
+### 1) Add dependency
 
-  // Using RecordsPagination trait:
-  let page_model: Page<u32> = match records.paginate(page, size) {
-    Ok(p) => p,
-    Err(e) => panic!("Error paginating records: {:?}", e),
-  };
+```bash
+cargo add page-hunter
 ```
 
-To create a new instance of a `Page` from known parameters:
-```rust,no_run
-  use page_hunter::{Page, PaginationResult};
+With optional features:
 
-  let items: Vec<u32> = vec![1, 2];
-  let page: usize = 0;
-  let size: usize = 2;
-  let total_elements: usize = 5;
-
-  let page_model_result: PaginationResult<Page<u32>> = Page::new(
-    &items,
-    page,
-    size,
-    total_elements,
-  );
+```bash
+cargo add page-hunter --features serde
+cargo add page-hunter --features utoipa
+cargo add page-hunter --features sqlx
 ```
 
-On feature `serde` enabled, you can serialize and deserialize a `Page` as follows:
+### 2) Paginate a `Vec<T>` in 30 seconds
+
 ```rust,no_run
-  use page_hunter::Page;
+use page_hunter::prelude::*;
 
-  let items: Vec<u32> = vec![1, 2];
-  let page: usize = 0;
-  let size: usize = 2;
-  let total_elements: usize = 5;
+fn main() {
+    let records = vec![1_u32, 2, 3, 4, 5];
+    let page: Page<u32> = paginate_records(&records, 0, 2).unwrap();
 
-  let page_model: Page<u32> = Page::new(
-    &items,
-    page,
-    size,
-    total_elements,
-  ).unwrap_or_else(|error| {
-    panic!("Error creating page model: {:?}", error);
-  });
-
-  let serialized_page: String = serde_json::to_string(&page_model)
-    .unwrap_or_else(|error| {
-      panic!("Error serializing page model: {:?}", error);
-  });
-
-  let deserialized_page: Page<u32> = serde_json::from_str(&serialized_page)
-    .unwrap_or_else(|error| {
-      panic!("Error deserializing page model: {:?}", error);
-  });
+    assert_eq!(page.get_items(), &vec![1, 2]);
+    assert_eq!(page.get_pages(), 3);
+    assert_eq!(page.get_next_page(), Some(1));
+}
 ```
 
-When you create a new `Page` instance from the constructor or deserialization, the following rules are validated for the fields on the page:
-- ***pages*** must be equal to ***total*** divided by ***size*** rounded up. When ***size*** is 0, ***pages*** must be 1.
-- ***page*** must be less than or equal to ***pages*** - 1.
-- if ***page*** is less than ***pages*** - 1, ***items*** length must be equal to ***size***.
-- if ***page*** is equal to ***pages*** - 1, ***total*** must be equal to (***pages*** - 1) * ***size*** + ***items*** length.
-- ***previous_page*** must be equal to ***page*** - 1 if ***page*** is greater than 0, otherwise it must be `None`.
-- ***next_page*** must be equal to ***page*** + 1 if ***page*** is less than ***pages*** - 1, otherwise it must be `None`.
+`prelude` is optional. You can always import each item manually.
 
-If any of these rules are violated, a `PaginationError` will be returned.
+## Core Models
 
-### Bind records:
-If you need to bind records into a `Book` model:
+### `Page<T>`
+
+Represents one page of records, including:
+
+- `items`
+- `page`
+- `size`
+- `total`
+- `pages`
+- `previous_page`
+- `next_page`
+
+Create directly when you already know values:
+
 ```rust,no_run
-  use page_hunter::{bind_records, Book, RecordsPagination};
+use page_hunter::{Page, PaginationResult};
 
-  let records: Vec<u32> = vec![1, 2, 3, 4, 5];
-  let size: usize = 2;
-
-  // Using the bind_records function:
-  let book: Book<u32> = match bind_records(&records, size) {
-    Ok(b) => b,
-    Err(e) => panic!("Error binding records: {:?}", e),
-  };
-
-  // Using RecordsPagination trait:
-  let book: Book<u32> = match records.bind(size) {
-    Ok(b) => b,
-    Err(e) => panic!("Error binding records: {:?}", e),
-  };
+let items = vec![1, 2];
+let page_model: PaginationResult<Page<u32>> = Page::new(&items, 0, 2, 5);
 ```
 
-To create a new `Book` instance from known parameters:
-```rust,no_run
-  use page_hunter::{Book, Page};
+### `Book<T>`
 
-  let sheets: Vec<Page<u32>> = vec![
+Represents a full set of pages:
+
+```rust,no_run
+use page_hunter::{Book, Page};
+
+let sheets: Vec<Page<u32>> = vec![
     Page::new(&vec![1, 2], 0, 2, 5).unwrap(),
     Page::new(&vec![3, 4], 1, 2, 5).unwrap(),
-  ];
+    Page::new(&vec![5], 2, 2, 5).unwrap(),
+];
 
-  let book: Book<u32> = Book::new(&sheets);
+let book: Book<u32> = Book::new(&sheets);
+assert_eq!(book.get_sheets().len(), 3);
 ```
 
-On feature `serde` enabled, you can serialize and deserialize a `Book` as follows:
+## Common Use Cases
+
+### Paginate records (`Page<T>`)
+
 ```rust,no_run
-  use page_hunter::{Book, Page};
+use page_hunter::{Page, RecordsPagination, paginate_records};
 
-  let sheets: Vec<Page<u32>> = vec![
-    Page::new(&vec![1, 2], 0, 2, 5).unwrap(),
-    Page::new(&vec![3, 4], 1, 2, 5).unwrap(),
-  ];
+let records = vec![10, 20, 30, 40, 50];
+let page = 1;
+let size = 2;
 
-  let book: Book<u32> = Book::new(&sheets);
+let a: Page<i32> = paginate_records(&records, page, size).unwrap();
+let b: Page<i32> = records.paginate(page, size).unwrap();
 
-  let serialized_book: String = serde_json::to_string(&book)
-    .unwrap_or_else(|error| {
-      panic!("Error serializing book model: {:?}", error);
-  });
-
-  let deserialized_book: Book<u32> = serde_json::from_str(&serialized_book)
-    .unwrap_or_else(|error| {
-      panic!("Error deserializing book model: {:?}", error);
-  });
+assert_eq!(a.get_items(), b.get_items());
 ```
 
-#### Generate OpenAPI schemas:
- On feature `utoipa` enabled, you can generate OpenAPI schemas for `Page` and `Book` models as follows:
-```rust,no_run
-  use page_hunter::{Book, Page};
-  use utoipa::{OpenApi, ToSchema};
-  use serde::{Deserialize, Serialize};
+### Bind all records (`Book<T>`)
 
-  #[derive(Clone, ToSchema)]
-  pub struct Person {
-    id: u16,
+```rust,no_run
+use page_hunter::{Book, RecordsPagination, bind_records};
+
+let records = vec![1, 2, 3, 4, 5];
+
+let a: Book<i32> = bind_records(&records, 2).unwrap();
+let b: Book<i32> = records.bind(2).unwrap();
+
+assert_eq!(a.get_sheets().len(), b.get_sheets().len());
+```
+
+### SQLx pagination (`sqlx` feature)
+
+`SQLxPagination::paginate` accepts either:
+
+- `&Pool<DB>`
+- `&mut DB::Connection`
+
+#### Using a connection pool
+
+```rust,no_run
+use page_hunter::{Page, SQLxPagination};
+use sqlx::postgres::{PgPool, Postgres};
+use sqlx::{FromRow, QueryBuilder};
+
+#[derive(Clone, Debug, FromRow)]
+struct Country {
+    id: i32,
     name: String,
-    last_name: String,
-    still_alive: bool,
-  }
+}
 
-  pub type PeoplePage = Page<Person>;
-  pub type PeopleBook = Book<Person>;
-
-  #[derive(OpenApi)]
-  #[openapi(
-    components(schemas(PeoplePage, PeopleBook))
-  )]
-  pub struct ApiDoc;
+async fn run(pool: PgPool) {
+    let query: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM geo.countries");
+    let page: Page<Country> = query.paginate(&pool, 0, 10).await.unwrap();
+    assert_eq!(page.get_page(), 0);
+}
 ```
 
-Take a look at the [examples](https://github.com/JMTamayo/page-hunter/tree/main/examples) folder where you can find practical uses in REST API implementations with some web frameworks.
+#### Using a single connection
 
-#### Paginate records from a relational database with SQLx:
-To paginate records from a Postgres database:
 ```rust,no_run
-  use page_hunter::{Page, SQLxPagination};
-  use sqlx::postgres::{PgConnection, Postgres};
-  use sqlx::{Connection, FromRow, QueryBuilder};
+use page_hunter::{Page, SQLxPagination};
+use sqlx::postgres::{PgConnection, Postgres};
+use sqlx::{Connection, FromRow, QueryBuilder};
 
-  #[tokio::main]
-  async fn main() {
-    #[derive(Clone, Debug, FromRow)]
-    pub struct Country {
-      id: i32,
-      name: String,
-    }
+#[derive(Clone, Debug, FromRow)]
+struct Country {
+    id: i32,
+    name: String,
+}
 
-    let mut conn: PgConnection = PgConnection::connect(
-      "postgres://username:password@localhost/db"
-    ).await.unwrap_or_else(|error| {
-      panic!("Error connecting to database: {:?}", error);
-    });
+async fn run() {
+    let mut conn = PgConnection::connect("postgres://username:password@localhost/db")
+        .await
+        .unwrap();
+    let query: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM geo.countries");
 
-    let query: QueryBuilder<Postgres> = QueryBuilder::new(
-      "SELECT * FROM db.geo.countries"
-    );
-
-    let page: Page<Country> =
-      query.paginate(&mut conn, 0, 10).await.unwrap_or_else(|error| {
-        panic!("Error paginating records: {:?}", error);
-    });
-  }
+    let page: Page<Country> = query.paginate(&mut conn, 0, 10).await.unwrap();
+    assert_eq!(page.get_size(), 10);
+}
 ```
 
-Similar to using pagination for Postgres, `SQLxPagination` can be used for MySQL and SQLite. If you are working with a connection pool, you can [Acquire](https://docs.rs/sqlx/latest/sqlx/trait.Acquire.html)  a single connection before running `paginate`.
+## Feature Flags
 
-## DEVELOPMENT
-To test `page-hunter`, follow these recommendations:
+| Feature | What you get |
+| --- | --- |
+| `serde` | `Serialize` / `Deserialize` for `Page` and `Book` |
+| `utoipa` | OpenAPI schemas via `ToSchema` (includes `serde`) |
+| `sqlx` | SQL query pagination support for Postgres/MySQL/SQLite via SQLx |
 
-#### Set env variables:
-Create `local.env` file at workspace folder to store the required environment variables. For example,
+## Validation Rules
+
+Every `Page` is validated when created (or deserialized). Some important rules:
+
+- `pages` must match `total` and `size` (`div_ceil`, minimum 1).
+- `page` must be within range `[0, pages - 1]`.
+- Non-last pages must have `items.len() == size`.
+- Last page must satisfy total consistency.
+- `previous_page` and `next_page` must be coherent.
+
+If validation fails, you get a `PaginationError`.
+
+## Typical Developer Commands
+
+### Format and lint
+
+```bash
+cargo fmt --package page-hunter --all
+cargo fmt --package page-hunter --all --check
+cargo clippy --package page-hunter --all-features
+```
+
+### Build and test
+
+```bash
+cargo check --package page-hunter --all-features
+cargo test --package page-hunter --all-features
+cargo test --package page-hunter --all-features --doc
+```
+
+### Generate docs
+
+```bash
+cargo doc --package page-hunter --all-features --open
+```
+
+### Security scan
+
+```bash
+cargo deny --log-level error check
+```
+
+### Run full CI locally
+
+Use the local helper script to run the same core flow as the GitHub CI (format, clippy matrix, check matrix, docs, tests, coverage, and security):
+
+```bash
+bash scripts/ci-local.sh
+```
+
+Optional shortcuts:
+
+```bash
+SKIP_DB=true bash scripts/ci-local.sh
+SKIP_COVERAGE=true bash scripts/ci-local.sh
+```
+
+## Local SQLx Test Setup
+
+Create `local.env` at workspace root:
+
 ```text
-  DB_HOST=localhost
-  DB_USER=test
-  DB_PASSWORD=docker
-  DB_NAME=test
-  PG_DB_PORT=5432
-  PG_MIGRATIONS_PATH=page-hunter/src/pagination/sqlx/tests/pg/migrations
+DB_HOST=localhost
+DB_USER=test
+DB_PASSWORD=docker
+DB_NAME=test
+PG_DB_PORT=5432
+PG_MIGRATIONS_PATH=page-hunter/src/pagination/sqlx/tests/pg/migrations
 ```
 
-#### Install required tools:
-Install the following tools required for the development process.
-
-##### [SQLx client](https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/README.md) for Postgres:
-```bash
-  cargo install sqlx-cli --no-default-features --features postgres
-```
-
-##### [Cargo LLVM cov](https://github.com/taiki-e/cargo-llvm-cov/blob/main/README.md):
-```bash
-  cargo install cargo-llvm-cov
-```
-
-##### [Cargo Nextest](https://nexte.std):
-```bash
-  cargo install cargo-nextest
-```
-
-##### [Cargo Deny](https://nexte.std):
-```bash
-  cargo install cargo-deny
-```
-
-#### Setup databases:
-Run Postgres database as a Docker container:
+Run test DB and migrations:
 
 ```bash
-  bash ./page-hunter/src/pagination/sqlx/tests/pg/scripts/run_db.sh
+bash ./page-hunter/src/pagination/sqlx/tests/pg/scripts/run_db.sh
+bash ./page-hunter/src/pagination/sqlx/tests/pg/scripts/run_migrations.sh
 ```
 
-#### Run database migrations:
+Revert migrations:
 
-- Run migrations:
 ```bash
-  bash ./page-hunter/src/pagination/sqlx/tests/pg/scripts/run_migrations.sh
+bash ./page-hunter/src/pagination/sqlx/tests/pg/scripts/revert_migration.sh
 ```
 
-- Revert migrations:
-```bash
-  bash ./page-hunter/src/pagination/sqlx/tests/pg/scripts/revert_migration.sh
-```
+## Examples
 
-#### To format the code:
-```bash
-  cargo fmt --package page-hunter --all
-```
+Real projects live in [examples/](https://github.com/JMTamayo/page-hunter/tree/main/examples):
 
-#### To verify the code format:
-```bash
-  cargo fmt --package page-hunter --all --check
-```
+- [examples/actix-web](https://github.com/JMTamayo/page-hunter/tree/main/examples/actix-web): paginate external API results.
+- [examples/axum](https://github.com/JMTamayo/page-hunter/tree/main/examples/axum): SQLx + PostgreSQL + OpenAPI.
 
-#### To verify lints:
-- No features:
-```bash
-  cargo clippy --package page-hunter
-```
+## Contributing
 
-- Feature `serde`:
-```bash
-  cargo clippy --package page-hunter --features serde
-```
+Contributions are welcome.
 
-- Feature `utoipa`:
-```bash
-  cargo clippy --package page-hunter --features utoipa
-```
+- Report bugs with reproduction steps.
+- Open feature proposals with clear use cases.
+- Send PRs with tests and consistent style.
 
-- Feature `sqlx`:
-```bash
-  cargo clippy --package page-hunter --features sqlx
-```
-
-- All features:
-```bash
-  cargo clippy --package page-hunter --all-features
-```
-
-#### To check the project:
-- No features:
-```bash
-  cargo check --package page-hunter
-```
-
-- Feature `serde`:
-```bash
-  cargo check --package page-hunter --features serde
-```
-
-- Feature `utoipa`:
-```bash
-  cargo check --package page-hunter --features utoipa
-```
-
-- Feature `sqlx`:
-```bash
-  cargo check --package page-hunter --features sqlx
-```
-
-- All features:
-```bash
-  cargo check --package page-hunter --all-features
-```
-
-#### To generate the documentation:
-```bash
-  cargo doc --package page-hunter --all-features --open
-```
-
-#### To run doc tests:
-```bash
-  cargo test --package page-hunter --all-features --doc
-```
-
-#### To test using llvm-cov:
-```bash
-  cargo llvm-cov nextest --workspace --all-features --show-missing-lines --open
-```
-
-### Security analysis:
-```bash
-  cargo deny --log-level error check
-```
-
-## CONTRIBUTIONS
-The ***Page Hunter*** project is open source and therefore any interested software developer can contribute to its improvement. To contribute, take a look at the following recommendations:
-
-- **Bug Reports**: If you find a bug, please create an issue detailing the problem, the steps to reproduce it, and the expected behavior.
-- **Feature Requests**: If you have an idea for a new feature or an enhancement to an existing one, please create an issue describing your idea.
-- **Pull Requests**: If you've fixed a bug or implemented a new feature, we'd love to see your work! Please submit a pull request. Make sure your code follows the existing style and all tests pass.
+If you are building APIs in Rust and want predictable pagination behavior, `page-hunter` is ready for production workflows.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,16 @@
-# PAGE HUNTER EXAMPLES
-This folder contains a set of practical examples that can help people to get started and to implement the library's utilities.
+# Page Hunter Examples
 
-Each example folder contains its own README.md file. Take a look at this file to understand the purpose of the example and to run it on your own computer.
+This directory contains runnable projects that show how to use `page-hunter` in real API scenarios.
 
-Enjoy them!
+## Available examples
+
+- `actix-web`: in-memory pagination and binding over data fetched from an external API.
+- `axum`: database-backed pagination with PostgreSQL and `sqlx`.
+
+## How to use this folder
+
+1. Choose an example directory.
+2. Follow that example's `README.md` step by step.
+3. Run the service and open its API docs in the browser.
+
+Each example is self-contained and has its own dependencies and run commands.

--- a/examples/actix-web/Cargo.toml
+++ b/examples/actix-web/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 license = "MIT"
 
 [dependencies]
-actix-web = { version = "4.12.1" }
-reqwest = { version = "0.12.26", features = ["json"] }
+actix-web = { version = "4.13.0" }
+reqwest = { version = "0.13.2", features = ["json"] }
 utoipa = { version = "5.4.0", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "9.0.2", features = ["actix-web"] }
 utoipa-redoc = { version = "6.0.0", features = ["actix-web"] }

--- a/examples/actix-web/README.md
+++ b/examples/actix-web/README.md
@@ -1,21 +1,36 @@
-# USING ACTIX WEB WITH PAGE HUNTER
-Use [actix-web](https://docs.rs/actix-web/4.6.0/actix_web/) to build a web server using `page-hunter` to paginate APIs responses.
+# Actix Web Example
 
-This service uses the [API Colombia](https://api-colombia.com) project to obtain data and implement page-hunter models and functions. Review the project documentation at the following links:
-- **Repository:** [https://github.com/Mteheran/api-colombia](https://github.com/Mteheran/api-colombia?tab=readme-ov-file)
-- **Web page:** [https://api-colombia.com](https://api-colombia.com)
-- **API doc:** [https://api-colombia.com/swagger/index.html](https://api-colombia.com/swagger/index.html)
+This example shows how to use `page-hunter` with [actix-web](https://docs.rs/actix-web/latest/actix_web/) for in-memory pagination APIs.
 
-To try this example on your local computer, you just need to locate to the respective folder and run the following command:
+It consumes data from [API Colombia](https://api-colombia.com) and demonstrates:
+
+- `paginate_records` for paged responses.
+- `bind_records` for grouped "book" responses.
+- OpenAPI documentation with `utoipa`.
+
+## Prerequisites
+
+- Rust toolchain (stable)
+- Internet connection (the app depends on API Colombia)
+
+## Run locally
+
+From this directory:
 
 ```bash
-	cargo run --release
+cargo run --release
 ```
 
-When the service is running, you can explore the documentation as follows:
-- **Swagger UI:** http://localhost:8080/swagger-ui/
-- **Rapidoc:** http://localhost:8080/rapidoc
-- **Redoc:** http://localhost:8080/redoc
-- **Scalar:**  http://localhost:8080/scalar
+The server starts at `http://127.0.0.1:8080`.
 
-Enjoy it! 😀
+## API documentation
+
+- Swagger UI: `http://localhost:8080/swagger-ui/`
+- RapiDoc: `http://localhost:8080/rapidoc`
+- Redoc: `http://localhost:8080/redoc`
+- Scalar: `http://localhost:8080/scalar`
+
+## Useful endpoints
+
+- `GET /departments/paged-list?page=1&size=10`
+- `GET /departments/book?size=10`

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2024"
 license = "MIT"
 
 [dependencies]
-tokio = { version = "1.48.0", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 axum = { version = "0.8.8" }
 utoipa = {version = "5.4.0", features = ["axum_extras", "uuid", "time"] }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "uuid", "time",  "postgres"] }
 serde = { version = "1.0.228", features = ["derive"] }
-time = { version = "0.3.44", features = ["serde"] }
-uuid = { version = "1.19.0", features = ["serde"] }
-env_logger = { version = "0.11.8" }
+time = { version = "0.3.47", features = ["serde"] }
+uuid = { version = "1.22.0", features = ["serde"] }
+env_logger = { version = "0.11.9" }
 log = { version = "0.4.29" }
 page-hunter = { path = "../../page-hunter", features=["utoipa", "sqlx"] }
 

--- a/examples/axum/README.md
+++ b/examples/axum/README.md
@@ -1,26 +1,68 @@
-# USING AXUM WITH PAGE HUNTER AND POSTGRESQL
-Use [axum](https://docs.rs/crate/axum/0.7.5) to build a web server using `page-hunter` to paginate APIs responses and PostgreSQL to manage data.
+# Axum + SQLx Example
 
-This service uses a PostgreSQL database as a docker container to manage example data.
+This example shows how to use `page-hunter` with [axum](https://docs.rs/axum/latest/axum/) and PostgreSQL through `sqlx`.
 
-To try this example on your local computer, you just need to locate to the respective folder and run the following command:
+It demonstrates:
 
-1. Install sqlx-cli:
+- SQL-backed pagination with `SQLxPagination`.
+- API handlers for categories and products.
+- OpenAPI docs with Swagger UI.
+
+## Prerequisites
+
+- Rust toolchain (stable)
+- Docker
+- `make`
+
+## Run locally
+
+From this directory:
+
+1. Install `sqlx-cli`:
+
 ```bash
-	make install-sqlx-cli
+make install-sqlx-cli
 ```
 
-2. Run database container:
+2. Start PostgreSQL container:
+
 ```bash
-	make run-db-container
+make run-db-container
 ```
 
-3. Run the application:
+3. Run migrations:
+
 ```bash
-	make run
+make run-db-migrations
 ```
 
-When the service is running, you can explore the documentation as follows:
-- **Swagger UI:** http://localhost:8080/swagger-ui/
+4. Export environment variables:
 
-Enjoy it! 😀
+```bash
+set -a
+source local.env
+set +a
+```
+
+5. Start the API:
+
+```bash
+make run
+```
+
+The server starts on `http://localhost:8080`.
+
+## API documentation
+
+- Swagger UI: `http://localhost:8080/swagger-ui/`
+
+## Useful endpoints
+
+- `GET /categories?page=1&size=10`
+- `GET /products?page=1&size=10`
+- `GET /products/{id}`
+
+## Notes
+
+- The default PostgreSQL mapping uses port `5432`.
+- If you already have a local PostgreSQL running on `5432`, stop it or run the container with a different mapped port.

--- a/examples/axum/src/db/repository/categories.rs
+++ b/examples/axum/src/db/repository/categories.rs
@@ -73,10 +73,8 @@ impl<'p> CategoriesRepositoryMethods for CategoriesRepository<'p> {
             None => debug!("No name_like provided"),
         }
 
-        let mut conn = self.get_pool().acquire().await?;
-
         let categories: PaginatedCategories = query
-            .paginate(&mut conn, search_by.get_page(), search_by.get_size())
+            .paginate(self.get_pool(), search_by.get_page(), search_by.get_size())
             .await?;
 
         Ok(categories)

--- a/examples/axum/src/db/repository/products.rs
+++ b/examples/axum/src/db/repository/products.rs
@@ -124,10 +124,8 @@ impl<'p> ProductsRepositoryMethods for ProductsRepository<'p> {
             None => debug!("No category_name_like provided"),
         }
 
-        let mut conn = self.get_pool().acquire().await?;
-
         let products_base: PaginatedProductsBase = query
-            .paginate(&mut conn, search_by.get_page(), search_by.get_size())
+            .paginate(self.get_pool(), search_by.get_page(), search_by.get_size())
             .await?;
 
         let products: PaginatedProducts = Page::new(

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -18,9 +18,9 @@ utoipa = { version = "5.4.0", optional = true }
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
-tokio ={ version = "1.48.0", features = ["full"] }
+tokio ={ version = "1.50.0", features = ["full"] }
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "postgres", "macros"] }
-serde_json = { version = "1.0.145" }
+serde_json = "1.0.149"
 
 [features]
 serde = ["dep:serde"]

--- a/page-hunter/Cargo.toml
+++ b/page-hunter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "page-hunter"
 description = "The pagination powerhouse, built with Rust"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Juan Manuel Tamayo <jmtamayog23@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/jmtamayo/page-hunter"
@@ -13,13 +13,13 @@ keywords = ["pagination", "paginator", "page_model"]
 categories = ["development-tools"]
 
 [dependencies]
-serde = { version = ">=1.0.228", features = ["derive"],  optional = true }
-utoipa = { version = ">=5.4.0", optional = true}
-sqlx = { version = ">=0.8.6", features = ["runtime-tokio"], optional = true }
+serde = { version = "1.0.228", features = ["derive"], optional = true }
+utoipa = { version = "5.4.0", optional = true }
+sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
 tokio ={ version = "1.48.0", features = ["full"] }
-sqlx = { version = "0.8.6", features = ["postgres"] }
+sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "postgres", "macros"] }
 serde_json = { version = "1.0.145" }
 
 [features]

--- a/page-hunter/src/lib.rs
+++ b/page-hunter/src/lib.rs
@@ -1,215 +1,117 @@
-//! ***Page Hunter*** library is a Rust-based pagination tool that provides a way to manage and navigate through pages of data.
-//! It offers a set of resources that encapsulates all the necessary pagination information such as the current page, total pages, previous page, next page and the items on the current page.
+//! `page-hunter` is a pagination library for Rust APIs and services.
 //!
-//! The library also includes validation methods to ensure the integrity of the pagination data.
-//! It's designed to be flexible and easy to integrate into any Rust project that requires pagination functionality standard data validation
+//! It provides:
 //!
-//! ## CRATE FEATURES
-//! - `serde`: Add [Serialize](https://docs.rs/serde/1.0.200/serde/trait.Serialize.html) and [Deserialize](https://docs.rs/serde/1.0.200/serde/trait.Deserialize.html) support for [`Page`] and [`Book`] based on [serde](https://crates.io/crates/serde/1.0.200). This feature is useful for implementing pagination models as a request or response body in REST APIs, among other implementations.
-//!  - `utoipa`: Add [ToSchema](https://docs.rs/utoipa/4.2.0/utoipa/trait.ToSchema.html) support for [`Page`] and  [`Book`] based on [utoipa](https://crates.io/crates/utoipa/4.2.0). This feature is useful for generating OpenAPI schemas for pagination models. This feature depends on the `serde` feature and therefore you only need to implement `utoipa` to get both.
-//! - `sqlx`: Add support for pagination with [SQLx](https://docs.rs/sqlx/0.8.1/sqlx/) for Postgres, MySQL and SQLite databases.
+//! - [`Page`]: a validated model for one page of records.
+//! - [`Book`]: a model that groups multiple pages.
+//! - Record helpers: [`paginate_records`], [`bind_records`], and [`RecordsPagination`].
+//! - SQLx integration via [`SQLxPagination`] when the `sqlx` feature is enabled.
 //!
-//! ## BASIC OPERATION
+//! ## Quick Start
 //!
-//! The **page-hunter** library provides two main models to manage pagination:
-//! - [`Page`]: Represents a page of records with the current page, total pages, previous page, next page, and the items on the current page.
-//! - [`Book`]: Represents a book of pages with a collection of [`Page`] instances.
-//!
-//! The library also provides a set of functions to paginate records into a [`Page`] model and bind records into a [`Book`] model. The following examples show how to use the **page-hunter** library:
-//!
-//! #### Paginate records:
-//! If you need to paginate records and get a specific [`Page`]:
 //! ```rust,no_run
-//!   use page_hunter::{Page, paginate_records, RecordsPagination};
+//! use page_hunter::prelude::*;
 //!
-//!   let records: Vec<u32> = vec![1, 2, 3, 4, 5];
-//!   let page: usize = 0;
-//!   let size: usize = 2;
+//! let records = vec![1_u32, 2, 3, 4, 5];
+//! let page: Page<u32> = paginate_records(&records, 0, 2).unwrap();
 //!
-//!   // Using the paginate_records function:
-//!   let page_model: Page<u32> = match paginate_records(&records, page, size) {
-//!     Ok(p) => p,
-//!     Err(e) => panic!("Error paginating records: {:?}", e),
-//!   };
-//!
-//!   // Using RecordsPagination trait:
-//!   let page_model: Page<u32> = match records.paginate(page, size) {
-//!     Ok(p) => p,
-//!     Err(e) => panic!("Error paginating records: {:?}", e),
-//!   };
+//! assert_eq!(page.get_items(), &vec![1, 2]);
+//! assert_eq!(page.get_pages(), 3);
+//! assert_eq!(page.get_next_page(), Some(1));
 //! ```
 //!
-//! To create a new `Page` instance from known parameters:
+//! ## Core Models
+//!
+//! - [`Page`] stores `items`, `page`, `size`, `total`, `pages`, `previous_page`, and `next_page`.
+//! - [`Book`] stores a list of [`Page`] values.
+//!
+//! Create a [`Page`] directly when you already know all values:
+//!
 //! ```rust,no_run
-//!   use page_hunter::{Page, PaginationResult};
+//! use page_hunter::{Page, PaginationResult};
 //!
-//!   let items: Vec<u32> = vec![1, 2];
-//!   let page: usize = 0;
-//!   let size: usize = 2;
-//!   let total_elements: usize = 5;
-//!
-//!   let page_model_result: PaginationResult<Page<u32>> = Page::new(
-//!     &items,
-//!     page,
-//!     size,
-//!     total_elements,
-//!   );
+//! let items = vec![1_u32, 2];
+//! let page_model: PaginationResult<Page<u32>> = Page::new(&items, 0, 2, 5);
 //! ```
 //!
-//! On feature `serde` enabled, you can serialize and deserialize a [`Page`] as follows:
+//! Build a [`Book`] from existing pages:
+//!
 //! ```rust,no_run
-//!   use page_hunter::Page;
+//! use page_hunter::{Book, Page};
 //!
-//!   let items: Vec<u32> = vec![1, 2];
-//!   let page: usize = 0;
-//!   let size: usize = 2;
-//!   let total_elements: usize = 5;
-//!
-//!   let page_model: Page<u32> = Page::new(
-//!     &items,
-//!     page,
-//!     size,
-//!     total_elements,
-//!   ).unwrap_or_else(|error| {
-//!     panic!("Error creating page model: {:?}", error);
-//!   });
-//!
-//!   let serialized_page: String = serde_json::to_string(&page_model)
-//!     .unwrap_or_else(|error| {
-//!       panic!("Error serializing page model: {:?}", error);
-//!   });
-//!
-//!   let deserialized_page: Page<u32> = serde_json::from_str(&serialized_page)
-//!     .unwrap_or_else(|error| {
-//!       panic!("Error deserializing page model: {:?}", error);
-//!   });
-//! ```
-//!
-//! When you create a new [`Page`] instance from the constructor or deserialization, the following rules are validated for the fields on the page:
-//! - ***pages*** must be equal to ***total*** divided by ***size*** rounded up. When ***size*** is 0, ***pages*** must be 1.
-//! - ***page*** must be less than or equal to ***pages*** - 1.
-//! - if ***page*** is less than ***pages*** - 1, ***items*** length must be equal to ***size***.
-//! - if ***page*** is equal to ***pages*** - 1, ***total*** must be equal to (***pages*** - 1) * ***size*** + ***items*** length.
-//! - ***previous_page*** must be equal to ***page*** - 1 if ***page*** is greater than 0, otherwise it must be [`None`].
-//! - ***next_page*** must be equal to ***page*** + 1 if ***page*** is less than ***pages*** - 1, otherwise it must be [`None`].
-//!
-//! If any of these rules are violated, a [`PaginationError`] will be returned.
-//!
-//! #### Bind records:
-//! If you need to bind records into a [`Book`] model:
-//! ```rust,no_run
-//!   use page_hunter::{bind_records, Book, RecordsPagination};
-//!
-//!   let records: Vec<u32> = vec![1, 2, 3, 4, 5];
-//!   let size: usize = 2;
-//!
-//!   // Using the bind_records function:
-//!   let book: Book<u32> = match bind_records(&records, size) {
-//!     Ok(b) => b,
-//!     Err(e) => panic!("Error binding records: {:?}", e),
-//!   };
-//!
-//!   // Using RecordsPagination trait:
-//!   let book: Book<u32> = match records.bind(size) {
-//!     Ok(b) => b,
-//!     Err(e) => panic!("Error binding records: {:?}", e),
-//!   };
-//! ```
-//!
-//! To create a new [`Book`] instance from known parameters:
-//! ```rust,no_run
-//!   use page_hunter::{Book, Page};
-//!
-//!   let sheets: Vec<Page<u32>> = vec![
+//! let sheets: Vec<Page<u32>> = vec![
 //!     Page::new(&vec![1, 2], 0, 2, 5).unwrap(),
 //!     Page::new(&vec![3, 4], 1, 2, 5).unwrap(),
-//!   ];
+//!     Page::new(&vec![5], 2, 2, 5).unwrap(),
+//! ];
 //!
-//!   let book: Book<u32> = Book::new(&sheets);
+//! let book: Book<u32> = Book::new(&sheets);
+//! assert_eq!(book.get_sheets().len(), 3);
 //! ```
 //!
-//! On feature `serde` enabled, you can serialize and deserialize a [`Book`] as follows:
+//! ## In-Memory Pagination
+//!
+//! Use either free functions or the trait extension:
+//!
 //! ```rust,no_run
-//!   use page_hunter::{Book, Page};
+//! use page_hunter::{Page, RecordsPagination, paginate_records};
 //!
-//!   let sheets: Vec<Page<u32>> = vec![
-//!     Page::new(&vec![1, 2], 0, 2, 5).unwrap(),
-//!     Page::new(&vec![3, 4], 1, 2, 5).unwrap(),
-//!   ];
+//! let records = vec![10, 20, 30, 40, 50];
+//! let a: Page<i32> = paginate_records(&records, 1, 2).unwrap();
+//! let b: Page<i32> = records.paginate(1, 2).unwrap();
 //!
-//!   let book: Book<u32> = Book::new(&sheets);
-//!
-//!   let serialized_book: String = serde_json::to_string(&book)
-//!     .unwrap_or_else(|error| {
-//!       panic!("Error serializing book model: {:?}", error);
-//!   });
-//!
-//!   let deserialized_book: Book<u32> = serde_json::from_str(&serialized_book)
-//!     .unwrap_or_else(|error| {
-//!       panic!("Error deserializing book model: {:?}", error);
-//!   });
+//! assert_eq!(a.get_items(), b.get_items());
 //! ```
 //!
-//! #### Generate OpenAPI schemas:
-//! On feature `utoipa` enabled, you can generate OpenAPI schemas for [`Page`] and [`Book`] models as follows:
-//! ```rust,no_run
-//!   use page_hunter::{Book, Page};
-//!   use utoipa::{OpenApi, ToSchema};
-//!   use serde::{Deserialize, Serialize};
+//! ## SQLx Pagination (`sqlx` feature)
 //!
-//!   #[derive(Clone, ToSchema)]
-//!   pub struct Person {
-//!     id: u16,
+//! [`SQLxPagination::paginate`] accepts both:
+//!
+//! - a pool reference (`&Pool<DB>`)
+//! - a single connection (`&mut DB::Connection`)
+//!
+//! Example with a connection:
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "sqlx")]
+//! # async fn run() {
+//! use page_hunter::{Page, SQLxPagination};
+//! use sqlx::postgres::{PgConnection, Postgres};
+//! use sqlx::{Connection, FromRow, QueryBuilder};
+//!
+//! #[derive(Clone, Debug, FromRow)]
+//! struct Country {
+//!     id: i32,
 //!     name: String,
-//!     last_name: String,
-//!     still_alive: bool,
-//!   }
+//! }
 //!
-//!   pub type PeoplePage = Page<Person>;
-//!   pub type PeopleBook = Book<Person>;
+//! let mut conn = PgConnection::connect("postgres://username:password@localhost/db")
+//!     .await
+//!     .unwrap();
+//! let query: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM geo.countries");
 //!
-//!   #[derive(OpenApi)]
-//!   #[openapi(
-//!     components(schemas(PeoplePage, PeopleBook))
-//!   )]
-//!   pub struct ApiDoc;
+//! let page: Page<Country> = query.paginate(&mut conn, 0, 10).await.unwrap();
+//! assert_eq!(page.get_size(), 10);
+//! # }
 //! ```
 //!
-//! Take a look at the [examples](https://github.com/JMTamayo/page-hunter/tree/main/examples)  folder where you can find practical uses in REST API implementations with some web frameworks.
+//! ## Feature Flags
 //!
-//! #### Paginate records from a relational database with SQLx:
-//! To paginate records from a Postgres database:
-//! ```rust,no_run
-//!   use page_hunter::{Page, SQLxPagination};
-//!   use sqlx::postgres::{PgConnection, Postgres};
-//!   use sqlx::{Connection, FromRow, QueryBuilder};
+//! - `serde`: adds `Serialize` and `Deserialize` support for [`Page`] and [`Book`].
+//! - `utoipa`: adds `ToSchema` support for [`Page`] and [`Book`] (depends on `serde`).
+//! - `sqlx`: enables SQL query pagination support via [`SQLxPagination`].
 //!
-//!   #[tokio::main]
-//!   async fn main() {
-//!     #[derive(Clone, Debug, FromRow)]
-//!     pub struct Country {
-//!       id: i32,
-//!       name: String,
-//!     }
+//! ## Validation Rules
 //!
-//!     let mut conn: PgConnection = PgConnection::connect(
-//!       "postgres://username:password@localhost/db"
-//!     ).await.unwrap_or_else(|error| {
-//!       panic!("Error connecting to database: {:?}", error);
-//!     });
+//! Every [`Page`] is validated on construction (and on deserialization when `serde` is enabled).
+//! Validation ensures internal consistency for pagination metadata, including page ranges,
+//! element counts, and previous/next pointers.
 //!
-//!     let query: QueryBuilder<Postgres> = QueryBuilder::new(
-//!       "SELECT * FROM db.geo.countries"
-//!     );
+//! Invalid data returns [`PaginationError`].
 //!
-//!     let page: Page<Country> =
-//!       query.paginate(&mut conn, 0, 10).await.unwrap_or_else(|error| {
-//!         panic!("Error paginating records: {:?}", error);
-//!     });
-//!   }
-//! ```
+//! ## See Also
 //!
-//! Similar to using pagination for Postgres, [`SQLxPagination`] can be used for MySQL and SQLite. If you are working with a connection pool, you can [Acquire](https://docs.rs/sqlx/latest/sqlx/trait.Acquire.html)  a single connection before running [paginate](`SQLxPagination::paginate`).
+//! - Repository examples: <https://github.com/JMTamayo/page-hunter/tree/main/examples>
 mod book;
 mod errors;
 mod page;
@@ -224,3 +126,24 @@ pub use results::PaginationResult;
 
 #[cfg(feature = "sqlx")]
 pub use pagination::sqlx::queries::SQLxPagination;
+
+/// Re-exports of the most commonly used `page-hunter` items.
+///
+/// This module is designed for ergonomic imports:
+///
+/// ```rust,no_run
+/// use page_hunter::prelude::*;
+///
+/// let records = vec![1_u32, 2, 3];
+/// let page: Page<u32> = paginate_records(&records, 0, 2).unwrap();
+/// assert_eq!(page.get_page(), 0);
+/// ```
+pub mod prelude {
+    pub use crate::{
+        Book, ErrorKind, Page, PaginationError, PaginationResult, RecordsPagination, bind_records,
+        paginate_records,
+    };
+
+    #[cfg(feature = "sqlx")]
+    pub use crate::SQLxPagination;
+}

--- a/page-hunter/src/pagination/sqlx/queries.rs
+++ b/page-hunter/src/pagination/sqlx/queries.rs
@@ -1,14 +1,16 @@
 use std::future::Future;
 
 use sqlx::{
-    ColumnIndex, Connection, Database, Decode, Error as SqlxError, Executor, FromRow,
-    IntoArguments, QueryBuilder, Transaction, Type, query, query_scalar,
+    Acquire, ColumnIndex, Database, Decode, Error as SqlxError, Executor, FromRow, IntoArguments,
+    QueryBuilder, Transaction, Type, query, query_scalar,
 };
 
-#[allow(unused_imports)]
-use crate::{ErrorKind, Page, PaginationError, PaginationResult};
+use crate::{Page, PaginationResult};
 
 /// Trait to paginate results from a SQL query into a [`Page`] model from database using [`sqlx`].
+///
+/// The implementation executes both `count(*)` and page data queries inside the same
+/// transaction created from the provided [`Acquire`] source.
 pub trait SQLxPagination<DB, S>
 where
     DB: Database,
@@ -22,7 +24,7 @@ where
     /// Available for Postgres, MySQL or SQLite databases.
     ///
     /// ### Arguments:
-    /// - **conn**: A mutable reference to a connection to the database.
+    /// - **source**: A database source implementing [`Acquire`], such as `&Pool<DB>` or `&mut DB::Connection`.
     /// - **page**: The page index.
     /// - **size**: The number of records per page.
     ///
@@ -30,12 +32,14 @@ where
     /// A [`PaginationResult`] containing a [`Page`] model of the paginated records `S`, where `S` must implement the [`FromRow`] for given [`Database::Row`] type according to the database.
     ///
     /// Only available when the `sqlx` feature is enabled.
-    fn paginate(
+    fn paginate<'c, A>(
         &self,
-        conn: &mut DB::Connection,
+        source: A,
         page: usize,
         size: usize,
-    ) -> impl Future<Output = PaginationResult<Page<S>>>;
+    ) -> impl Future<Output = PaginationResult<Page<S>>>
+    where
+        A: Acquire<'c, Database = DB> + Send;
 }
 
 impl<DB, S> SQLxPagination<DB, S> for QueryBuilder<'_, DB>
@@ -47,16 +51,19 @@ where
     usize: ColumnIndex<<DB>::Row>,
     S: for<'r> FromRow<'r, DB::Row> + Clone,
 {
-    fn paginate(
+    fn paginate<'c, A>(
         &self,
-        conn: &mut DB::Connection,
+        source: A,
         page: usize,
         size: usize,
-    ) -> impl Future<Output = PaginationResult<Page<S>>> {
-        let query_str: &str = self.sql();
+    ) -> impl Future<Output = PaginationResult<Page<S>>>
+    where
+        A: Acquire<'c, Database = DB> + Send,
+    {
+        let query_str: String = self.sql().to_owned();
 
         async move {
-            let mut tx: Transaction<'_, DB> = conn.begin().await?;
+            let mut tx: Transaction<'_, DB> = source.begin().await?;
 
             let total: usize = query_scalar::<DB, i64>(&format!(
                 "SELECT count(*) from ({query_str}) as temp_table;"

--- a/page-hunter/src/pagination/sqlx/tests/test_pg.rs
+++ b/page-hunter/src/pagination/sqlx/tests/test_pg.rs
@@ -5,7 +5,6 @@ pub mod test_sqlx_pg_pagination {
 
     use sqlx::{
         Connection, FromRow, QueryBuilder,
-        pool::PoolConnection,
         postgres::{PgConnection, PgPool, PgPoolOptions, Postgres},
     };
 
@@ -38,12 +37,10 @@ pub mod test_sqlx_pg_pagination {
             .await
             .unwrap();
 
-        let mut conn: PoolConnection<Postgres> = pool.acquire().await.unwrap();
-
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 2, 3).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 2, 3).await;
         assert!(users_pagination.is_ok());
 
         let users: Page<User> = users_pagination.unwrap();
@@ -139,12 +136,10 @@ pub mod test_sqlx_pg_pagination {
             .await
             .unwrap();
 
-        let mut conn: PoolConnection<Postgres> = pool.acquire().await.unwrap();
-
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 2, 3).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 2, 3).await;
         assert!(users_pagination.is_err());
 
         let error: String = users_pagination.unwrap_err().to_string();
@@ -181,12 +176,10 @@ pub mod test_sqlx_pg_pagination {
             .await
             .unwrap();
 
-        let mut conn: PoolConnection<Postgres> = pool.acquire().await.unwrap();
-
         let query: QueryBuilder<Postgres> =
             QueryBuilder::<Postgres>::new("SELECT * FROM test_page_hunter.users");
 
-        let users_pagination: PaginationResult<Page<User>> = query.paginate(&mut conn, 5, 30).await;
+        let users_pagination: PaginationResult<Page<User>> = query.paginate(&pool, 5, 30).await;
         assert!(users_pagination.is_err());
 
         let error: String = users_pagination.unwrap_err().to_string();


### PR DESCRIPTION
## Summary
- refactor SQLx pagination to accept generic `Acquire` sources, enabling `&Pool<DB>` and `&mut DB::Connection` on the same `paginate` API (breaking change)
- improve release/docs quality: refresh root docs, crate docs, and examples READMEs; add `prelude` exports and update changelog entries with explicit attribution
- harden delivery pipeline and maintenance tooling: strengthen CI workflow, add local CI helper flow, and align dependency versions for crate + examples

## Test plan
- [x] Run `bash scripts/ci-local.sh` with default DB port (`5432`)
- [x] Verify `cargo fmt --check` passes
- [x] Verify clippy/check feature matrix passes
- [x] Verify tests and docs checks pass (including rustdoc/doctests in CI local script)

Made with [Cursor](https://cursor.com)